### PR TITLE
Fix linking on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-book
 *.lock
+.DS_Store
+book
 target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-csound_sys = { package = "csound-sys", version = "0.1.2" }
+# csound_sys = { package = "csound-sys", version = "0.1.2" }
+csound_sys = { package = "csound-sys", path = "csound-sys" }
 bitflags = { package = "bitflags", version = "1.0.4" }
 libc = { package = "libc", version= "0.2", default-features = false }
 va_list = { package = "va_list", version = "0.1.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-# csound_sys = { package = "csound-sys", version = "0.1.2" }
-csound_sys = { package = "csound-sys", path = "csound-sys" }
+csound_sys = { package = "csound-sys", version = "0.1.2" }
 bitflags = { package = "bitflags", version = "1.0.4" }
 libc = { package = "libc", version= "0.2", default-features = false }
 va_list = { package = "va_list", version = "0.1.3" }

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ so, It could be a good idea if you export this path in your bashrc or write a pr
 
 ### macOS
 
-Please be free to send a pull request with the changes applied to the build
-scripts and instructions about how to use this crate along csound's native library
+`CsoundLib64.framework` is expected in `/Library/Frameworks/`. If it's installed
+in a different path specify `CSOUND_LIB_DIR` for that.
 
 <a name="installation-windows"/>
 

--- a/csound-sys/build.rs
+++ b/csound-sys/build.rs
@@ -1,45 +1,98 @@
 use std::env;
-use std::env::consts;
 use std::path::Path;
 
 fn main() {
-
-    let dylib_name;
-    let target = env::var("TARGET").unwrap();
-
-    if !target.contains("windows") {
-        
-        // csound lib name on unix
-        dylib_name = format!("{}csound64{}", consts::DLL_PREFIX, consts::DLL_SUFFIX);
-        let mut paths = Vec::new();
-        
-        // posible paths to find this library
-        paths.push(Path::new("/usr/lib"));
-        paths.push(Path::new("/usr/local/lib"));
-        
-        for path in paths.as_slice() {
-            if path.join(&dylib_name).exists() {
-                println!("cargo:rustc-link-search=native={}", path.display());
-                println!("cargo:rustc-link-lib=csound64");
-                return;
-            }
-        }
-    } else {
-        // windows case
-        dylib_name = "csound64.lib".to_owned();
+    if !link() {
+        println!("cargo:warning=libcsound64 library not found in your system");
+        println!(
+            "export the CSOUND_LIB_DIR env var with the path to the csound library, for example "
+        );
+        println!("export CSOUND_LIB_DIR=/usr/lib  ");
+        panic!();
     }
-     
+}
 
+#[cfg(target_os = "linux")]
+fn link() -> bool {
+    use std::env::consts;
+
+    let dylib_name = format!("{}csound64{}", consts::DLL_PREFIX, consts::DLL_SUFFIX);
+
+    if check_custom_path(&dylib_name) {
+        return true;
+    }
+
+    let mut paths = Vec::new();
+    // posible paths to find this library
+    paths.push(Path::new("/usr/lib"));
+    paths.push(Path::new("/usr/local/lib"));
+    for path in paths.as_slice() {
+        if path.join(&dylib_name).exists() {
+            println!("cargo:rustc-link-search=native={}", path.display());
+            link_cmd();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+#[cfg(target_os = "windows")]
+fn link() -> bool {
+    let dylib_name = String::from("csound64.lib");
+    return check_custom_path(&dylib_name);
+}
+
+#[cfg(target_os = "macos")]
+fn link() -> bool {
+    let framework = String::from("CsoundLib64.framework");
+
+    if check_custom_path(&framework) {
+        return true;
+    }
+
+    let path_str = format!("/Library/Frameworks/{}", framework);
+
+    if !Path::new(&path_str).exists() {
+        return false;
+    }
+
+    link_cmd();
+
+    return true;
+}
+
+fn check_custom_path(name: &str) -> bool {
     if let Some(lib_dir) = env::var_os("CSOUND_LIB_DIR") {
         let lib_dir = Path::new(&lib_dir);
-        if lib_dir.join(dylib_name).exists() {
-            println!("cargo:rustc-link-search=native={}", lib_dir.display());
-            println!("cargo:rustc-link-lib=csound64");
-            return;
+
+        if !lib_dir.join(name).exists() {
+            return false;
         }
+
+        if cfg!(linux) || cfg!(windows) {
+            println!("cargo:rustc-link-search=native={}", lib_dir.display());
+            link_cmd();
+        } else if cfg!(macos) {
+            println!("cargo:rustc-link-search=framework={}", lib_dir.display());
+            link_cmd();
+        } else {
+            unimplemented!()
+        }
+
+        return true;
     }
-    println!("cargo:warning=libcsound64 library not found in your system");
-    println!("export the CSOUND_LIB_DIR env var with the path to the csound library, for example ");
-    println!("export CSOUND_LIB_DIR=/usr/lib  ");
-    panic!();
+
+    return false;
+}
+
+fn link_cmd() {
+    if cfg!(target_os = "linux") || cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=csound64");
+    } else if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-search=framework=/Library/Frameworks");
+        println!("cargo:rustc-link-lib=framework=CsoundLib64");
+    } else {
+        unimplemented!()
+    }
 }

--- a/csound-sys/build.rs
+++ b/csound-sys/build.rs
@@ -39,15 +39,14 @@ fn link() -> bool {
 
 #[cfg(target_os = "windows")]
 fn link() -> bool {
-    let dylib_name = String::from("csound64.lib");
-    return check_custom_path(&dylib_name);
+    return check_custom_path("csound64.lib");
 }
 
 #[cfg(target_os = "macos")]
 fn link() -> bool {
-    let framework = String::from("CsoundLib64.framework");
+    let framework = "CsoundLib64.framework";
 
-    if check_custom_path(&framework) {
+    if check_custom_path(framework) {
         return true;
     }
 

--- a/examples/src/example1.rs
+++ b/examples/src/example1.rs
@@ -1,36 +1,10 @@
 use csound::Csound;
 
-static CSD: &str = "<CsoundSynthesizer>
-<CsOptions>
--odac
-</CsOptions>
-<CsInstruments>
-sr = 44100
-ksmps = 32
-nchnls = 2
-0dbfs  = 1
-instr 1
-kamp = .6
-kcps = 440
-ifn  = p4
-asig oscil kamp, kcps, ifn
-     outs asig,asig
-endin
-</CsInstruments>
-<CsScore>
-f1 0 16384 10 1
-i 1 0 2 1
-e
-</CsScore>
-</CsoundSynthesizer>";
-
 fn main() {
     let cs = Csound::new();
 
-    let args = ["csound", CSD];
+    let args = ["csound", "examples/test1.csd"];
     cs.compile(&args).unwrap();
-
-    cs.start().unwrap();
-
     cs.perform();
+    cs.stop();
 }

--- a/examples/src/example1.rs
+++ b/examples/src/example1.rs
@@ -1,4 +1,3 @@
-extern crate csound;
 use csound::Csound;
 
 static CSD: &str = "<CsoundSynthesizer>

--- a/examples/src/example10.rs
+++ b/examples/src/example10.rs
@@ -23,10 +23,8 @@
  */
 
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-extern crate csound;
 use csound::{ControlChannel, Csound, InputChannel};
-
-extern crate rand;
+use rand;
 
 /* Trait with update/rest functions*/
 pub trait RandomFunc {

--- a/examples/src/example2.rs
+++ b/examples/src/example2.rs
@@ -10,7 +10,6 @@
  * source, such as from a database or network.
  */
 
-extern crate csound;
 use csound::Csound;
 
 /* Defining our Csound ORC code within a multiline String */

--- a/examples/src/example3.rs
+++ b/examples/src/example3.rs
@@ -7,7 +7,6 @@
  * safely at block boundaries.  We will explore the technique further in later examples.
  */
 
-extern crate csound;
 use csound::Csound;
 
 /* Defining our Csound ORC code within a multiline String */

--- a/examples/src/example5.rs
+++ b/examples/src/example5.rs
@@ -30,11 +30,9 @@
  * you want to hear, and comment out the others.
  */
 
-extern crate csound;
 use csound::Csound;
 use std::fmt::Write;
 
-extern crate rand;
 use rand::Rng;
 
 use std::sync::{Arc, Mutex};

--- a/examples/src/example6.rs
+++ b/examples/src/example6.rs
@@ -10,11 +10,9 @@
  * and offset the start time.
  */
 
-extern crate csound;
 use csound::Csound;
 use std::fmt::Write;
 
-extern crate rand;
 use rand::Rng;
 
 #[derive(Default, Debug, Copy, Clone)]

--- a/examples/src/example7.rs
+++ b/examples/src/example7.rs
@@ -23,10 +23,8 @@
  * increment and by decrementing the duration.
  */
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-extern crate csound;
 use csound::*;
-
-extern crate rand;
+use rand;
 
 #[derive(Default)]
 pub struct random_line {

--- a/examples/src/example8.rs
+++ b/examples/src/example8.rs
@@ -20,10 +20,8 @@
  */
 
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-extern crate csound;
 use csound::{ControlChannel, Csound};
-
-extern crate rand;
+use rand;
 
 #[derive(Default)]
 pub struct random_line {

--- a/examples/src/example9.rs
+++ b/examples/src/example9.rs
@@ -12,10 +12,8 @@
  */
 
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-extern crate csound;
 use csound::{ControlChannel, Csound, InputChannel};
-
-extern crate rand;
+use rand;
 
 #[derive(Default)]
 pub struct random_line {

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -110,13 +110,16 @@ impl Csound {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
+    /// use csound::{Csound, MessageType};
+    ///
     ///  // Creates a Csound instance and use a custom callback handler
     /// let csound = Csound::new();
     /// // enable the message callback passing a closure to the custom callback handler
-    /// csound.message_string_callback( |mtype:u32, message:&str| {
-    ///     println!("message type: {} message content:  {}", mtype, message);
+    /// csound.message_string_callback( |mtype: MessageType, message: &str| {
+    ///     println!("message type: {:?} message content:  {}", mtype, message);
     /// });
+    /// # let csd_filename = "file.csd";
     /// csound.compile_csd(csd_filename).unwrap();
     /// csound.start();
     /// ```
@@ -169,11 +172,14 @@ impl Csound {
     /// the <CsOptions> tag is ignored, and performance continues indefinitely or until ended using the API.
     /// # Example
     ///
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
+    /// # let csd_filename = "file.csd";
     /// let csound = Csound::new();
     /// csound.compile_csd(csd_filename).unwrap();
     /// csound.start();
-    /// ...
+    /// // ...
     /// ```
     ///
     pub fn start(&self) -> Result<(), &'static str> {
@@ -251,15 +257,19 @@ impl Csound {
     /// the <CsScore> element is not pre-processed, but dispatched as real-time events;
     /// and performance continues indefinitely, or until ended by calling [`Csound::stop`](struct.Csound.html#method.stop) or some other logic.
     /// In this "real-time" mode, the sequence of calls should be:
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound  = Csound::new();
     /// csound.set_option("-an_option");
     /// csound.set_option("-another_option");
     /// csound.start();
+    /// # let csd_filename = "file.csd";
     /// csound.compile_csd(csd_filename);
-    /// while true{
+    /// let pfields = [1.0, 0.0, 5.0, 4.5, 6.2];
+    /// loop {
     ///     // Send realtime events
-    ///     csound.send_score_event("i 1 0 5 4.5 6.2");
+    ///     csound.send_score_event('i', &pfields);
     ///     //...
     ///     // some logic to break the loop after a performance of realtime events
     /// }
@@ -267,14 +277,17 @@ impl Csound {
     /// *Note*: this function can be called repeatedly during performance to replace or add new instruments and events.
     /// But if csoundCompileCsd is called before csoundStart, the <CsOptions> element is used,the <CsScore> section is pre-processed and dispatched normally,
     /// and performance terminates when the score terminates, or [`Csound::stop`](struct.Csound.html#method.stop)  is called.
-    ///  In this "non-real-time" mode (which can still output real-time audio and handle real-time events), the sequence of calls should be:
-    ///  ```
-    ///  let csound  = Csound::new();
-    ///  csound.compile_csd(csd_filename);
-    ///  csound.start();
-    ///  while !csound.perform_ksmps() {
-    ///  }
-    ///  ```
+    /// In this "non-real-time" mode (which can still output real-time audio and handle real-time events), the sequence of calls should be:
+    /// ```no_run
+    /// use csound::Csound;
+    ///
+    /// let csound  = Csound::new();
+    /// # let csd_filename = "file.csd";
+    /// csound.compile_csd(csd_filename);
+    /// csound.start();
+    /// while !csound.perform_ksmps() {
+    /// }
+    /// ```
     /// # Arguments
     /// * `csd` A reference to .csd file name
     pub fn compile_csd<T>(&self, csd: T) -> Result<(), &'static str>
@@ -311,6 +324,8 @@ impl Csound {
     /// Parses and compiles the given orchestra from an ASCII string, also evaluating any global space code (i-time only)
     /// this can be called during performance to compile a new orchestra.
     /// ```
+    /// use csound::Csound;
+    ///
     /// let csound  = Csound::new();
     /// let orc_code = "instr 1
     ///                 a1 rand 0dbfs/4
@@ -599,6 +614,8 @@ impl Csound {
     /// Get output type and format.
     /// # Example
     /// ```
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// let (output_type, output_format) = csound.get_output_format().unwrap();
     /// ```
@@ -696,14 +713,16 @@ impl Csound {
     /// csound's input buffer has not been initialized. The returned *BufferPtr* is Writable, it means that you can modify
     /// the csound's buffer content in order to write external audio data into csound and process it.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
     /// let input_buffer_ptr = csound.get_input_buffer();
     /// while !csound.perform_buffer() {
     ///     // fills your buffer with audio samples that you want to pass into csound
-    ///     foo_fill_buffer(input_buffer_ptr.as_mut_slice());
+    ///     // foo_fill_buffer(input_buffer_ptr.as_mut_slice());
     ///     // ...
     /// }
     /// ```
@@ -727,15 +746,17 @@ impl Csound {
     /// An Option containing either the [`BufferPtr`](struct.BufferPtr.html) or None if the
     /// csound's output buffer has not been initialized. The returned *BufferPtr* is only Readable.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
     /// let output_buffer_ptr = csound.get_output_buffer();
-    /// let mut data = vec![0f64; input_buffer_ptr.get_size()];
+    /// let mut data = vec![0f64; output_buffer_ptr.unwrap().get_size()];
     /// while !csound.perform_buffer() {
     ///     // process the data from csound
-    ///     foo_process_buffer(output_buffer_ptr.as_slice());
+    ///     // foo_process_buffer(output_buffer_ptr.as_slice());
     /// }
     /// ```
     pub fn get_output_buffer(&self) -> Option<BufferPtr<Readable>> {
@@ -758,14 +779,16 @@ impl Csound {
     /// An Option containing either the [`BufferPtr`](struct.BufferPtr.html) or None if the
     /// csound's spin buffer has not been initialized. The returned *BufferPtr* is Writable.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
     /// let spin = csound.get_spin();
     /// while !csound.perform_ksmps() {
     ///     // fills the spin buffer with audio samples that you want to pass into csound
-    ///     foo_fill_buffer(spin.as_mut_slice());
+    ///     // foo_fill_buffer(spin.as_mut_slice());
     ///     // ...
     /// }
     /// ```
@@ -789,14 +812,16 @@ impl Csound {
     /// An Option containing either the [`BufferPtr`](struct.BufferPtr.html) or None if the
     /// csound's spout buffer has not been initialized. The returned *BufferPtr* is only Readable.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
     /// let spout = csound.get_spout();
     /// while !csound.perform_ksmps() {
     ///     // Deref the spout pointer and read its content
-    ///     foo_read_buffer(&*spout);
+    ///     // foo_read_buffer(&*spout);
     ///     // ...
     /// }
     /// ```
@@ -824,7 +849,9 @@ impl Csound {
     /// The number of samples copied into the slice on success, or an
     /// error message if the internal csound's buffer has not been initialized.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
@@ -867,15 +894,17 @@ impl Csound {
     /// The number of samples copied into the csound's input buffer or an
     /// error message if the internal csound's buffer has not been initialized.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
     /// let input_buffer_length = csound.get_input_buffer_size();
-    /// let mut input_buffer = vec![0f64; output_buffer_length];
+    /// let mut input_buffer = vec![0f64; input_buffer_length];
     /// while !csound.perform_buffer() {
     ///     // fills your buffer with audio samples you want to pass into csound
-    ///     foo_fill_buffer(&mut input_buffer);
+    ///     // foo_fill_buffer(&mut input_buffer);
     ///     csound.write_input_buffer(&input_buffer);
     ///     // ...
     /// }
@@ -908,7 +937,9 @@ impl Csound {
     /// The number of samples copied  or an
     /// error message if the internal csound's buffer has not been initialized.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
@@ -916,8 +947,8 @@ impl Csound {
     /// let mut spout_buffer = vec![0f64; spout_length as usize];
     /// while !csound.perform_ksmps() {
     ///     // fills your buffer with audio samples you want to pass into csound
-    ///     foo_fill_buffer(&mut spout_buffer);
-    ///     csound.read_spout_buffer(&spout_buffer);
+    ///     // foo_fill_buffer(&mut spout_buffer);
+    ///     csound.read_spout_buffer(&mut spout_buffer);
     ///     // ...
     /// }
     /// ```
@@ -947,7 +978,9 @@ impl Csound {
     /// The number of samples copied  or an
     /// error message if the internal csound's buffer has not been initialized.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// csound.compile_csd("some_file_path");
     /// csound.start();
@@ -955,7 +988,7 @@ impl Csound {
     /// let mut spin_buffer = vec![0f64; spin_length as usize];
     /// while !csound.perform_ksmps() {
     ///     // fills your buffer with audio samples you want to pass into csound
-    ///     foo_fill_buffer(&mut spin_buffer);
+    ///     // foo_fill_buffer(&mut spin_buffer);
     ///     csound.write_spin_buffer(&spin_buffer);
     ///     // ...
     /// }
@@ -1771,6 +1804,9 @@ impl Csound {
     /// * `pvs_data` Reference to tha struct which will be filled with the pvs data.
     /// # Example
     /// ```
+    /// use csound::{Csound, PvsDataExt};
+    ///
+    /// let cs = Csound::new();
     /// let mut pvs = PvsDataExt::new(512);
     /// cs.get_pvs_channel("1", &mut pvs);
     /// ```
@@ -1843,7 +1879,9 @@ impl Csound {
     /// * `event_type` is the score event type ('a', 'i', 'q', 'f', or 'e').
     /// * `pfields` is a slice of f64 values with all the pfields for this event.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let cs = Csound::new();
     /// let pFields = [1.0, 1.0, 5.0];
     /// while cs.perform_ksmps() == false {
@@ -1914,7 +1952,9 @@ impl Csound {
 
     /// Input a string (as if from a console), used for line events.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let cs = Csound::new();
     /// let pFields = [1.0, 1.0, 5.0];
     /// while cs.perform_ksmps() == false {
@@ -2124,7 +2164,9 @@ impl Csound {
     /// # Arguments
     /// * `table` The function table identifier.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let cs = Csound::new();
     /// cs.compile_csd("some.csd");
     /// cs.start().unwrap();
@@ -2133,9 +2175,9 @@ impl Csound {
     ///     // Gets the function table 1
     ///     let mut table = cs.get_table(1).unwrap();
     ///     // Copies the table content into table_buff
-    ///     table.read( table_buff.as_mut_slice() ).unwrap();
+    ///     // table.read( table_buff.as_mut_slice() ).unwrap();
     ///     // Do some stuffs
-    ///     table.write(&table_buff.into_iter().map(|x| x*2.5).collect::<Vec<f64>>().as_mut_slice());
+    ///     // table.write(&table_buff.into_iter().map(|x| x*2.5).collect::<Vec<f64>>().as_mut_slice());
     ///     // Do some stuffs
     /// }
     /// ```
@@ -2367,6 +2409,8 @@ impl Csound {
     /// A CircularBuffer
     /// # Example
     /// ```
+    /// use csound::Csound;
+    ///
     /// let csound = Csound::new();
     /// let circular_buffer = csound.create_circular_buffer::<f64>(1024);
     /// ```
@@ -2511,6 +2555,7 @@ impl Csound {
     /// and a reference to the message content.
     /// # Example
     /// ```
+    /// use csound::{Csound, MessageType};
     /// let mut cs = Csound::new();
     /// cs.message_string_callback(|att: MessageType, message: &str| print!("{}", message));
     /// ```
@@ -2541,10 +2586,12 @@ impl Csound {
     /// are supported.
     /// # Example
     /// ```
-    /// let input_channel = |name: &str|->ChannelData {
+    /// use csound::{Csound, ChannelData};
+    ///
+    /// let input_channel = |name: &str| -> ChannelData {
     ///      if name == "myStringChannel"{
     ///          let myString = "my data".to_owned();
-    ///          ChannelData::CS_STRING_CHANNEL(myString)
+    ///          ChannelData::CS_STRING_CHANNEL(myString);
     ///      }
     ///      ChannelData::CS_UNKNOWN_CHANNEL
     /// };
@@ -2569,6 +2616,8 @@ impl Csound {
     /// are supported.
     /// # Example
     /// ```
+    /// use csound::{Csound, ChannelData};
+    ///
     /// let output_channel = |name: &str, data:ChannelData|{
     ///      print!("channel name:{}  data: {:?}", name, data);
     /// };
@@ -2856,15 +2905,17 @@ impl<'a> Table<'a> {
     /// # Returns
     /// The number of elements copied into the output slice.
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let cs = Csound::new();
     /// cs.compile_csd("some.csd");
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {
     ///     let mut table = cs.get_table(1).unwrap();
-    ///     let mut table_buff = vec![0f64; table.length];
+    ///     let mut table_buff = vec![0f64; table.len()];
     ///     // copy Table::length elements from the table's internal buffer
-    ///     table.copy_to_slice( table_buff.as_mut_slice() ).unwrap();
+    ///     table.copy_to_slice( table_buff.as_mut_slice() );
     ///     // Do some stuffs
     /// }
     /// ```
@@ -2887,15 +2938,17 @@ impl<'a> Table<'a> {
     /// # Returns
     /// The number of elements copied into the table
     /// # Example
-    /// ```
+    /// ```no_run
+    /// use csound::Csound;
+    ///
     /// let cs = Csound::new();
     /// cs.compile_csd("some.csd");
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {
     ///     let mut table = cs.get_table(1).unwrap();
-    ///     let mut table_buff = vec![0f64; table.length];
+    ///     let mut table_buff = vec![0f64; table.len()];
     ///     // copy Table::length elements from the table's internal buffer
-    ///     table.read( table_buff.as_mut_slice() ).unwrap();
+    ///     // table.read( table_buff.as_mut_slice() ).unwrap();
     ///     // Do some stuffs
     ///     table.copy_from_slice(&table_buff.into_iter().map(|x| x*2.5).collect::<Vec<f64>>().as_mut_slice());
     ///     // Do some stuffs

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -329,7 +329,8 @@ impl Csound {
     /// let csound  = Csound::new();
     /// let orc_code = "instr 1
     ///                 a1 rand 0dbfs/4
-    ///                 out a1";
+    ///                 out a1
+    ///                 endin";
     /// csound.compile_orc(orc_code);
     /// ```
     /// # Arguments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod rtaudio;
 
 pub use callbacks::FileInfo;
 pub use channels::{ChannelHints, ChannelInfo, InputChannel, OutputChannel, PvsDataExt};
-pub use csound::{BufferPtr, CircularBuffer, Csound, OpcodeListEntry, Table};
+pub use crate::csound::{BufferPtr, CircularBuffer, Csound, OpcodeListEntry, Table};
 pub use enums::{
     AudioChannel, ChannelData, ControlChannel, FileTypes, Language, MessageType, Status, StrChannel,
 };


### PR DESCRIPTION
This PR:

- fixes linking on macOS, as we link against framework there
- fixes examples in the docs, so `cargo test` passes
- fixes `example1.rs`
- removes `extern crate` from examples as it's not needed in modern Rust