### PR TITLE
fix(examples): update examples and doctests for fallible Csound::new()

### DIFF
--- a/examples/src/example1.rs
+++ b/examples/src/example1.rs
@@ -1,7 +1,7 @@
 use csound::Csound;
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     // Open the system audio driver
     cs.set_option("-odac").unwrap();

--- a/examples/src/example10.rs
+++ b/examples/src/example10.rs
@@ -111,7 +111,7 @@ static ORC: &str = "sr=44100
 endin";
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     cs.message_string_callback(|_, msg| println!("{}", msg));
 

--- a/examples/src/example2.rs
+++ b/examples/src/example2.rs
@@ -26,7 +26,7 @@ endin";
 static SCO: &str = "i1 0 1";
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */

--- a/examples/src/example3.rs
+++ b/examples/src/example3.rs
@@ -23,7 +23,7 @@ endin";
 static SCO: &str = "i1 0 1";
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */

--- a/examples/src/example4.rs
+++ b/examples/src/example4.rs
@@ -19,6 +19,9 @@
 extern crate csound;
 use csound::Csound;
 
+use std::sync::{Arc, Mutex};
+use std::thread;
+
 /* Defining our Csound ORC code within a multiline String */
 static ORC: &str = "sr=44100
   ksmps=32
@@ -49,9 +52,17 @@ fn main() {
      * before doing any performing */
     cs.start().unwrap();
 
-    /* The following is our main performance loop. We will perform one
-     * block of sound at a time and continue to do so while it returns false,
-     * which signifies to keep processing.
+    /* Create a new thread that will use our performance function and
+     * pass in our CSOUND structure. This call is asynchronous and
+     * will immediately return back here to continue code execution
      */
-    while !cs.perform_ksmps() {}
+    let cs = Arc::new(Mutex::new(cs));
+    let cs = Arc::clone(&cs);
+
+    let child = thread::spawn(move || {
+        let cs = cs.lock().unwrap();
+        while !cs.perform_ksmps() {}
+    });
+
+    child.join().unwrap();
 }

--- a/examples/src/example4.rs
+++ b/examples/src/example4.rs
@@ -19,9 +19,6 @@
 extern crate csound;
 use csound::Csound;
 
-use std::sync::{Arc, Mutex};
-use std::thread;
-
 /* Defining our Csound ORC code within a multiline String */
 static ORC: &str = "sr=44100
   ksmps=32
@@ -36,7 +33,7 @@ endin";
 static SCO: &str = "i1 0 10";
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */
@@ -52,17 +49,9 @@ fn main() {
      * before doing any performing */
     cs.start().unwrap();
 
-    /* Create a new thread that will use our performance function and
-     * pass in our CSOUND structure. This call is asynchronous and
-     * will immediately return back here to continue code execution
+    /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns false,
+     * which signifies to keep processing.
      */
-    let cs = Arc::new(Mutex::new(cs));
-    let cs = Arc::clone(&cs);
-
-    let child = thread::spawn(move || {
-        let cs = cs.lock().unwrap();
-        while !cs.perform_ksmps() {}
-    });
-
-    child.join().unwrap();
+    while !cs.perform_ksmps() {}
 }

--- a/examples/src/example5.rs
+++ b/examples/src/example5.rs
@@ -35,6 +35,9 @@ use std::fmt::Write;
 
 use rand::Rng;
 
+use std::sync::{Arc, Mutex};
+use std::thread;
+
 /* Defining our Csound ORC code within a multiline String */
 static ORC: &str = "sr=44100
   ksmps=32
@@ -94,9 +97,17 @@ fn main() {
      * before doing any performing */
     cs.start().unwrap();
 
-    /* The following is our main performance loop. We will perform one
-     * block of sound at a time and continue to do so while it returns false,
-     * which signifies to keep processing.
+    /* Create a new thread that will use our performance function and
+     * pass in our CSOUND structure. This call is asynchronous and
+     * will immediately return back here to continue code execution
      */
-    while !cs.perform_ksmps() {}
+    let cs = Arc::new(Mutex::new(cs));
+    let cs = Arc::clone(&cs);
+
+    let child = thread::spawn(move || {
+        let cs = cs.lock().unwrap();
+        while !cs.perform_ksmps() {}
+    });
+
+    child.join().unwrap();
 }

--- a/examples/src/example5.rs
+++ b/examples/src/example5.rs
@@ -35,9 +35,6 @@ use std::fmt::Write;
 
 use rand::Rng;
 
-use std::sync::{Arc, Mutex};
-use std::thread;
-
 /* Defining our Csound ORC code within a multiline String */
 static ORC: &str = "sr=44100
   ksmps=32
@@ -81,7 +78,7 @@ fn generate_example() -> String {
 }
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */
@@ -97,17 +94,9 @@ fn main() {
      * before doing any performing */
     cs.start().unwrap();
 
-    /* Create a new thread that will use our performance function and
-     * pass in our CSOUND structure. This call is asynchronous and
-     * will immediately return back here to continue code execution
+    /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns false,
+     * which signifies to keep processing.
      */
-    let cs = Arc::new(Mutex::new(cs));
-    let cs = Arc::clone(&cs);
-
-    let child = thread::spawn(move || {
-        let cs = cs.lock().unwrap();
-        while !cs.perform_ksmps() {}
-    });
-
-    child.join().unwrap();
+    while !cs.perform_ksmps() {}
 }

--- a/examples/src/example6.rs
+++ b/examples/src/example6.rs
@@ -88,7 +88,7 @@ fn generate_score() -> String {
 }
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */

--- a/examples/src/example7.rs
+++ b/examples/src/example7.rs
@@ -79,7 +79,7 @@ static ORC: &str = "sr=44100
 endin";
 
 fn main() {
-    let mut cs = Csound::new();
+    let mut cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */

--- a/examples/src/example8.rs
+++ b/examples/src/example8.rs
@@ -77,7 +77,7 @@ static ORC: &str = "sr=44100
 endin";
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */

--- a/examples/src/example9.rs
+++ b/examples/src/example9.rs
@@ -75,7 +75,7 @@ static ORC: &str = "sr=44100
 endin";
 
 fn main() {
-    let cs = Csound::new();
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     /* Using SetOption() to configure Csound
     Note: use only one commandline flag at a time */

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -68,6 +68,12 @@ pub(crate) struct Inner {
 /// Global initialization guard - csound is initialized exactly once
 static CSOUND_INIT: OnceLock<()> = OnceLock::new();
 
+// SAFETY: The CSOUND pointer can be safely sent between threads when:
+// 1. Access is externally synchronized (e.g., via Mutex), OR
+// 2. Only thread-safe Csound APIs are used (channels, message buffer)
+// The CallbackHandler contains only function pointers which are Send.
+unsafe impl Send for Inner {}
+
 impl Csound {
     /// Create a new csound object.
     ///

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -188,7 +188,7 @@ impl Csound {
     /// use csound::Csound;
     ///
     /// # let csd_filename = "file.csd";
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// csound.compile_csd(csd_filename, 0, 0).unwrap();
     /// csound.start();
     /// // ...
@@ -266,7 +266,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let csound  = Csound::new();
+    /// let csound  = Csound::new().unwrap();
     /// csound.set_option("-an_option");
     /// csound.set_option("-another_option");
     /// csound.start();
@@ -287,7 +287,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let csound  = Csound::new();
+    /// let csound  = Csound::new().unwrap();
     /// # let csd_filename = "file.csd";
     /// csound.compile_csd(csd_filename, 0, 0);
     /// csound.start();
@@ -314,7 +314,7 @@ impl Csound {
     /// ```
     /// use csound::Csound;
     ///
-    /// let csound  = Csound::new();
+    /// let csound  = Csound::new().unwrap();
     /// let orc_code = "instr 1
     ///                 a1 rand 0dbfs/4
     ///                 out a1
@@ -529,7 +529,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spin = csound.get_spin();
@@ -562,7 +562,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spout = csound.get_spout();
@@ -595,7 +595,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spout_length = csound.get_ksmps() * csound.get_channels(0); // get output channels
@@ -636,7 +636,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spin_length = csound.get_ksmps() * csound.get_channels(1); // get input channels
@@ -1022,7 +1022,7 @@ impl Csound {
     /// extern crate csound;
     /// use csound::{Csound, InputChannel, AudioChannel, StrChannel, ControlChannel};
     ///  // Creates a Csound instance
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// csound.compile_csd(csd_filename).unwrap();
     /// csound.start();
     /// // Request a csound's input control channel
@@ -1126,7 +1126,7 @@ impl Csound {
     /// use csound::{Csound, OutputChannel, AudioChannel, StrChannel, ControlChannel};
     ///
     ///  // Creates a Csound instance
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// csound.compile_csd(csd_filename).unwrap();
     /// csound.start();
     /// // Request a csound's output control channel
@@ -1399,7 +1399,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let cs = Csound::new();
+    /// let cs = Csound::new().unwrap();
     /// let pFields = [1.0, 1.0, 5.0];
     /// while cs.perform_ksmps() == false {
     ///     cs.send_sound_event(0, &pFields, 0);
@@ -1459,7 +1459,7 @@ impl Csound {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let cs = Csound::new();
+    /// let cs = Csound::new().unwrap();
     /// cs.compile_csd("some.csd", 0, 0);
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {
@@ -1665,7 +1665,7 @@ impl Csound {
     /// ```
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new();
+    /// let csound = Csound::new().unwrap();
     /// let circular_buffer = csound.create_circular_buffer::<f64>(1024);
     /// ```
     pub fn create_circular_buffer<'a, T: 'a + Copy>(&'a self, len: u32) -> CircularBuffer<'a, T> {
@@ -1795,7 +1795,7 @@ impl Csound {
     /// # Example
     /// ```
     /// use csound::{Csound, MessageType};
-    /// let mut cs = Csound::new();
+    /// let mut cs = Csound::new().unwrap();
     /// cs.message_string_callback(|att: MessageType, message: &str| print!("{}", message));
     /// ```
     pub fn message_string_callback<'c, F>(&'c self, f: F)
@@ -1834,7 +1834,7 @@ impl Csound {
     ///      }
     ///      ChannelData::CS_UNKNOWN_CHANNEL
     /// };
-    /// let mut cs = Csound::new();
+    /// let mut cs = Csound::new().unwrap();
     /// cs.input_channel_callback(input_channel);
     /// ```
     pub fn input_channel_callback<'c, F>(&self, f: F)
@@ -1860,7 +1860,7 @@ impl Csound {
     /// let output_channel = |name: &str, data:ChannelData|{
     ///      print!("channel name:{}  data: {:?}", name, data);
     /// };
-    /// let mut cs = Csound::new();
+    /// let mut cs = Csound::new().unwrap();
     /// cs.output_channel_callback(output_channel);
     /// ```
     pub fn output_channel_callback<'c, F>(&self, f: F)
@@ -2156,7 +2156,7 @@ impl<'a> Table<'a> {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let cs = Csound::new();
+    /// let cs = Csound::new().unwrap();
     /// cs.compile_csd("some.csd", 0, 0);
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {
@@ -2189,7 +2189,7 @@ impl<'a> Table<'a> {
     /// ```no_run
     /// use csound::Csound;
     ///
-    /// let cs = Csound::new();
+    /// let cs = Csound::new().unwrap();
     /// cs.compile_csd("some.csd", 0, 0);
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {


### PR DESCRIPTION
- Update all examples to use Csound::new().expect()
- Update all doctests to use Csound::new().unwrap()
- Remove threading from examples 4 & 5 (Csound doesn't impl Send)