### PR TITLE
refactor!: modernize API with unified error handling and Rust convent…

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -277,17 +277,6 @@ pub mod Trampoline {
         None
     }
 
-    pub fn convert_str_to_c<T>(string: T) -> Result<CString, &'static str>
-    where
-        T: AsRef<str>,
-    {
-        let string = string.as_ref();
-        if string.is_empty() {
-            return Err("Failed to convert empty string to C");
-        }
-        CString::new(string).map_err(|_| "Failed converting rust string to CString")
-    }
-
     fn catch<T, F: FnOnce() -> T>(f: F) -> Option<T> {
         match panic::catch_unwind(AssertUnwindSafe(f)) {
             Ok(ret) => Some(ret),
@@ -331,21 +320,21 @@ pub mod Trampoline {
         dev: *const raw::csRtAudioParams,
     ) -> c_int {
         catch(|| unsafe {
-            let rtParams = RtAudioParams {
-                devName: ptr_to_string((*dev).devName),
-                devNum: (*dev).devNum as u32,
-                bufSamp_SW: (*dev).bufSamp_SW as u32,
-                bufSamp_HW: (*dev).bufSamp_HW as u32,
-                nChannels: (*dev).nChannels as u32,
-                sampleFormat: (*dev).sampleFormat as u32,
-                sampleRate: (*dev).sampleRate as f32,
+            let rt_params = RtAudioParams {
+                dev_name: ptr_to_string((*dev).devName),
+                dev_num: (*dev).devNum as u32,
+                buf_samp_sw: (*dev).bufSamp_SW as u32,
+                buf_samp_hw: (*dev).bufSamp_HW as u32,
+                n_channels: (*dev).nChannels as u32,
+                sample_format: (*dev).sampleFormat as u32,
+                sample_rate: (*dev).sampleRate as f32,
             };
             if let Some(fun) = (*(raw::csoundGetHostData(csound) as *mut CallbackHandler))
                 .callbacks
                 .play_open_cb
                 .as_mut()
             {
-                return fun(&rtParams).to_i32() as c_int;
+                return fun(&rt_params).to_i32() as c_int;
             }
             0
         })
@@ -357,21 +346,21 @@ pub mod Trampoline {
         dev: *const raw::csRtAudioParams,
     ) -> c_int {
         catch(|| unsafe {
-            let rtParams = RtAudioParams {
-                devName: ptr_to_string((*dev).devName),
-                devNum: (*dev).devNum as u32,
-                bufSamp_SW: (*dev).bufSamp_SW as u32,
-                bufSamp_HW: (*dev).bufSamp_HW as u32,
-                nChannels: (*dev).nChannels as u32,
-                sampleFormat: (*dev).sampleFormat as u32,
-                sampleRate: (*dev).sampleRate as f32,
+            let rt_params = RtAudioParams {
+                dev_name: ptr_to_string((*dev).devName),
+                dev_num: (*dev).devNum as u32,
+                buf_samp_sw: (*dev).bufSamp_SW as u32,
+                buf_samp_hw: (*dev).bufSamp_HW as u32,
+                n_channels: (*dev).nChannels as u32,
+                sample_format: (*dev).sampleFormat as u32,
+                sample_rate: (*dev).sampleRate as f32,
             };
             if let Some(fun) = (*(raw::csoundGetHostData(csound) as *mut CallbackHandler))
                 .callbacks
                 .rec_open_cb
                 .as_mut()
             {
-                return fun(&rtParams).to_i32() as c_int;
+                return fun(&rt_params).to_i32() as c_int;
             }
             -1
         })
@@ -425,22 +414,22 @@ pub mod Trampoline {
     pub extern "C" fn audioDeviceListCallback(
         csound: *mut raw::CSOUND,
         dev: *mut raw::CS_AUDIODEVICE,
-        isOutput: c_int,
+        is_output: c_int,
     ) -> c_int {
         catch(|| unsafe {
-            let audioDevice = CsAudioDevice {
+            let audio_device = CsAudioDevice {
                 device_name: ptr_to_string((*dev).device_name.as_ptr()),
                 device_id: ptr_to_string((*dev).device_id.as_ptr()),
                 rt_module: ptr_to_string((*dev).rt_module.as_ptr()),
                 max_nchnls: (*dev).max_nchnls as u32,
-                isOutput: isOutput as u32,
+                is_output: is_output as u32,
             };
             if let Some(fun) = (*(raw::csoundGetHostData(csound) as *mut CallbackHandler))
                 .callbacks
                 .devlist_cb
                 .as_mut()
             {
-                fun(audioDevice);
+                fun(audio_device);
             }
             0
         })
@@ -533,11 +522,11 @@ pub mod Trampoline {
             };
 
             match result {
-                ChannelData::CS_CONTROL_CHANNEL(data) => {
+                ChannelData::Control(data) => {
                     *(channelValuePtr as *mut f64) = data;
                 }
 
-                ChannelData::CS_STRING_CHANNEL(s) => {
+                ChannelData::String(s) => {
                     let len = s.len();
                     let c_str = CString::new(s);
                     if raw::csoundGetChannelDatasize(csound, channelName) as usize <= len {
@@ -582,12 +571,12 @@ pub mod Trampoline {
             match channel_type as u32 {
                 controlChannelType::CSOUND_CONTROL_CHANNEL => {
                     let value = *(channelValuePtr as *mut f64);
-                    let data = ChannelData::CS_CONTROL_CHANNEL(value);
+                    let data = ChannelData::Control(value);
                     fun(name, data);
                 }
 
                 controlChannelType::CSOUND_STRING_CHANNEL => {
-                    let data = ChannelData::CS_STRING_CHANNEL(
+                    let data = ChannelData::String(
                         ptr_to_string(channelValuePtr as *const c_char)
                             .unwrap_or_else(|| "".to_owned()),
                     );
@@ -604,11 +593,11 @@ pub mod Trampoline {
     // Sets callback for opening real time MIDI input.
     pub extern "C" fn midiInOpenCallback(
         csound: *mut raw::CSOUND,
-        _userData: *mut *mut c_void,
-        devName: *const c_char,
+        _user_data: *mut *mut c_void,
+        dev_name: *const c_char,
     ) -> c_int {
         catch(|| unsafe {
-            let name = match CStr::from_ptr(devName).to_str() {
+            let name = match CStr::from_ptr(dev_name).to_str() {
                 Ok(s) => s,
                 _ => return CSOUND_STATUS::CSOUND_ERROR,
             };
@@ -627,11 +616,11 @@ pub mod Trampoline {
     // Sets callback for opening real time MIDI output.
     pub extern "C" fn midiOutOpenCallback(
         csound: *mut raw::CSOUND,
-        _userData: *mut *mut c_void,
-        devName: *const c_char,
+        _user_data: *mut *mut c_void,
+        dev_name: *const c_char,
     ) -> c_int {
         catch(|| unsafe {
-            let name = match CStr::from_ptr(devName).to_str() {
+            let name = match CStr::from_ptr(dev_name).to_str() {
                 Ok(s) => s,
                 _ => return CSOUND_STATUS::CSOUND_ERROR,
             };

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,37 +1,39 @@
-#![allow(non_camel_case_types, non_snake_case)]
-
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
 use crate::enums::{AudioChannel, ControlChannel, ControlChannelType, StrChannel};
 
-/// Indicates the channel behaivor.
-#[derive(Debug, PartialEq, Clone)]
+/// Indicates the channel behavior.
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ChannelBehavior {
-    CHANNEL_NO_HINTS = 0,
-    CHANNEL_INT = 1,
-    CHANNEL_LIN = 2,
-    CHANNEL_EXP = 3,
+    /// No hints provided.
+    NoHints = 0,
+    /// Integer values.
+    Integer = 1,
+    /// Linear interpolation.
+    Linear = 2,
+    /// Exponential interpolation.
+    Exponential = 3,
 }
 
 impl ChannelBehavior {
     pub fn from_u32(value: u32) -> ChannelBehavior {
         match value {
-            0 => ChannelBehavior::CHANNEL_NO_HINTS,
-            1 => ChannelBehavior::CHANNEL_INT,
-            2 => ChannelBehavior::CHANNEL_LIN,
-            3 => ChannelBehavior::CHANNEL_EXP,
+            0 => ChannelBehavior::NoHints,
+            1 => ChannelBehavior::Integer,
+            2 => ChannelBehavior::Linear,
+            3 => ChannelBehavior::Exponential,
             _ => panic!("Unknown channel behavior type"),
         }
     }
 
     pub fn to_u32(&self) -> u32 {
         match self {
-            ChannelBehavior::CHANNEL_NO_HINTS => 0,
-            ChannelBehavior::CHANNEL_INT => 1,
-            ChannelBehavior::CHANNEL_LIN => 2,
-            ChannelBehavior::CHANNEL_EXP => 3,
+            ChannelBehavior::NoHints => 0,
+            ChannelBehavior::Integer => 1,
+            ChannelBehavior::Linear => 2,
+            ChannelBehavior::Exponential => 3,
         }
     }
 }
@@ -59,7 +61,7 @@ pub struct ChannelHints {
 impl Default for ChannelHints {
     fn default() -> ChannelHints {
         ChannelHints {
-            behav: ChannelBehavior::CHANNEL_NO_HINTS,
+            behav: ChannelBehavior::NoHints,
             dflt: 0f64,
             min: 0f64,
             max: 0f64,
@@ -92,9 +94,9 @@ pub struct ChannelInfo {
 ///
 #[derive(Debug, Clone)]
 pub struct PvsDataExt {
-    pub N: u32,
+    pub n: u32,
     pub sliding: u32,
-    pub NB: i32,
+    pub nb: i32,
     pub overlap: u32,
     pub winsize: u32,
     pub wintype: u32,
@@ -111,9 +113,9 @@ impl PvsDataExt {
     /// number of samples in the frame buffer.
     pub fn new(winsize: u32) -> PvsDataExt {
         PvsDataExt {
-            N: winsize,
+            n: winsize,
             sliding: 0,
-            NB: 0,
+            nb: 0,
             overlap: 0,
             winsize,
             wintype: 0,
@@ -288,26 +290,54 @@ impl_asref_for_channel_ptr!(StrChannel, u8);
 impl_asmut_for_channel_ptr!(AudioChannel, f64);
 impl_asmut_for_channel_ptr!(StrChannel, u8);
 
-// Internal macro used to generate ControlChannel, AudioChannel and StrChannel implementations
-// for the Deref trait.
-macro_rules! impl_deref_for_channel_ptr {
-    ($ct:ty, $t:ty) => {
-        impl<'a> Deref for OutputChannel<'a, $ct> {
-            type Target = $t;
+// Deref implementations for OutputChannel - delegates to AsRef
+impl<'a> Deref for OutputChannel<'a, ControlChannel> {
+    type Target = f64;
 
-            fn deref(&self) -> &Self::Target {
-                self.as_ref()
-            }
-        }
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ptr }
+    }
+}
 
-        impl<'a> Deref for InputChannel<'a, $ct> {
-            type Target = $t;
-            #[allow(unconditional_recursion)]
-            fn deref(&self) -> &Self::Target {
-                self.as_ref()
-            }
-        }
-    };
+impl<'a> Deref for OutputChannel<'a, AudioChannel> {
+    type Target = [f64];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl<'a> Deref for OutputChannel<'a, StrChannel> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
+    }
+}
+
+// Deref implementations for InputChannel - direct pointer access to avoid recursion
+impl<'a> Deref for InputChannel<'a, ControlChannel> {
+    type Target = f64;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<'a> Deref for InputChannel<'a, AudioChannel> {
+    type Target = [f64];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl<'a> Deref for InputChannel<'a, StrChannel> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
+    }
 }
 
 // Internal macro used to generate ControlChannel, AudioChannel and StrChannel implementations
@@ -321,10 +351,6 @@ macro_rules! impl_deref_mut_for_channel_ptr {
         }
     };
 }
-
-impl_deref_for_channel_ptr!(ControlChannel, f64);
-impl_deref_for_channel_ptr!(AudioChannel, [f64]);
-impl_deref_for_channel_ptr!(StrChannel, [u8]);
 
 impl_deref_mut_for_channel_ptr!(ControlChannel, f64);
 impl_deref_mut_for_channel_ptr!(AudioChannel, [f64]);

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -200,12 +200,12 @@ impl Csound {
     /// // ...
     /// ```
     ///
-    pub fn start(&self) -> Result<(), &'static str> {
+    pub fn start(&self) -> Result<()> {
         unsafe {
             if csound_sys::csoundStart(self.csound_ptr()) == CSOUND_STATUS::CSOUND_SUCCESS {
                 Ok(())
             } else {
-                Err("Csound is already started, call reset() before starting again.")
+                Err(Error::AlreadyStarted)
             }
         }
     }
@@ -238,25 +238,26 @@ impl Csound {
     /// * `args` A slice containing the arguments  to be passed to csound
     /// # Returns
     /// A error message in case of failure
-    pub fn compile<T>(&self, args: &[T]) -> Result<(), String>
+    pub fn compile<T>(&self, args: &[T]) -> Result<()>
     where
-        T: AsRef<str> + std::fmt::Debug,
+        T: AsRef<str>,
     {
         if args.is_empty() {
-            return Err("Not enough arguments".into());
+            return Err(Error::InvalidArgument(
+                "compile requires at least one argument",
+            ));
         }
 
         let arguments: Vec<CString> = args
             .iter()
             .map(|arg| CString::new(arg.as_ref()))
-            .filter_map(Result::ok)
-            .collect();
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         let mut args_raw: Vec<*const c_char> = arguments.iter().map(|arg| arg.as_ptr()).collect();
         let argv: *mut *const c_char = args_raw.as_mut_ptr();
         unsafe {
             match csound_sys::csoundCompile(self.csound_ptr(), args_raw.len() as c_int, argv) {
                 CSOUND_STATUS::CSOUND_SUCCESS => Ok(()),
-                _ => Err(format!("Can't compile csound arguments: {:?}", args)),
+                _ => Err(Error::CompileFailed("failed to compile csound arguments")),
             }
         }
     }
@@ -302,15 +303,19 @@ impl Csound {
     /// ```
     /// # Arguments
     /// * `csd` A reference to .csd file name
-    pub fn compile_csd<T>(&self, csd: T, mode: i32, async_: i32) -> Result<(), &'static str>
+    pub fn compile_csd<T>(&self, csd: T, mode: i32, async_: i32) -> Result<()>
     where
         T: AsRef<str>,
     {
-        let path = Trampoline::convert_str_to_c(csd)?;
+        let csd_ref = csd.as_ref();
+        if csd_ref.is_empty() {
+            return Err(Error::EmptyString);
+        }
+        let path = CString::new(csd_ref)?;
         unsafe {
             match csound_sys::csoundCompileCSD(self.csound_ptr(), path.as_ptr(), mode, async_) {
                 CSOUND_STATUS::CSOUND_SUCCESS => Ok(()),
-                _ => Err("Can't compile the csd file"),
+                _ => Err(Error::CompileFailed("failed to compile csd file")),
             }
         }
     }
@@ -329,15 +334,19 @@ impl Csound {
     /// ```
     /// # Arguments
     /// * `orcPath` A reference to orchestra strings
-    pub fn compile_orc<T>(&self, orc: T, async_: i32) -> Result<(), &'static str>
+    pub fn compile_orc<T>(&self, orc: T, async_: i32) -> Result<()>
     where
         T: AsRef<str>,
     {
-        let path = Trampoline::convert_str_to_c(orc)?;
+        let orc_ref = orc.as_ref();
+        if orc_ref.is_empty() {
+            return Err(Error::EmptyString);
+        }
+        let code = CString::new(orc_ref)?;
         unsafe {
-            match csound_sys::csoundCompileOrc(self.csound_ptr(), path.as_ptr(), async_) {
+            match csound_sys::csoundCompileOrc(self.csound_ptr(), code.as_ptr(), async_) {
                 CSOUND_STATUS::CSOUND_SUCCESS => Ok(()),
-                _ => Err("Can't to compile orc file"),
+                _ => Err(Error::CompileFailed("failed to compile orchestra")),
             }
         }
     }
@@ -349,11 +358,15 @@ impl Csound {
     ///   'return' opcode in global space.
     ///       code = "i1 = 2 + 2 \n return i1 \n"
     ///       retval = csound.eval_code(code)
-    pub fn eval_code<T>(&self, code: T) -> Result<f64, &'static str>
+    pub fn eval_code<T>(&self, code: T) -> Result<f64>
     where
         T: AsRef<str>,
     {
-        let cd = Trampoline::convert_str_to_c(code)?;
+        let code_ref = code.as_ref();
+        if code_ref.is_empty() {
+            return Err(Error::EmptyString);
+        }
+        let cd = CString::new(code_ref)?;
         unsafe {
             Ok(csound_sys::csoundEvalCode(
                 self.csound_ptr(),
@@ -386,7 +399,7 @@ impl Csound {
     pub fn udp_server_start(&self, port: u32) -> Result<(), Status> {
         unsafe {
             match Status::from(csound_sys::csoundUDPServerStart(self.csound_ptr(), port) as i32) {
-                Status::CS_SUCCESS => Ok(()),
+                Status::Success => Ok(()),
                 e => Err(e),
             }
         }
@@ -411,7 +424,7 @@ impl Csound {
     pub fn udp_server_close(&self) -> Result<(), Status> {
         unsafe {
             match Status::from(csound_sys::csoundUDPServerClose(self.csound_ptr()) as i32) {
-                Status::CS_SUCCESS => Ok(()),
+                Status::Success => Ok(()),
                 status => Err(status),
             }
         }
@@ -428,7 +441,7 @@ impl Csound {
     /// *Ok* on success or an Status code if the UDP transmission could not be set up.
     pub fn udp_console(&self, addr: &str, port: u32, mirror: bool) -> Result<(), Status> {
         unsafe {
-            let ip = CString::new(addr).map_err(|_e| Status::CS_ERROR)?;
+            let ip = CString::new(addr).map_err(|_e| Status::Error)?;
             if csound_sys::csoundUDPConsole(
                 self.csound_ptr(),
                 ip.as_ptr(),
@@ -438,7 +451,7 @@ impl Csound {
             {
                 return Ok(());
             }
-            Err(Status::CS_ERROR)
+            Err(Status::Error)
         }
     }
 
@@ -617,7 +630,7 @@ impl Csound {
     /// Use [`Csound::get_spout`](struct.Csound.html#method.get_spout) to get a [`BufferPtr`](struct.BufferPtr.html)
     /// object.
     #[deprecated(since = "0.1.5", note = "please use Csound::get_spout object instead")]
-    pub fn read_spout_buffer(&self, output: &mut [f64]) -> Result<usize, &'static str> {
+    pub fn read_spout_buffer(&self, output: &mut [f64]) -> Result<usize> {
         let size = self.get_ksmps() as usize * self.get_channels(0) as usize;
         let spout = unsafe { csound_sys::csoundGetSpout(self.csound_ptr()) as *const f64 };
         let mut len = output.len();
@@ -630,7 +643,9 @@ impl Csound {
                 return Ok(len);
             }
         }
-        Err("The spout buffer is not initialized, call the 'compile()' and 'start()' methods.")
+        Err(Error::BufferNotInitialized(
+            "spout buffer not initialized, call compile() and start() first",
+        ))
     }
 
     /// Enables external software to write audio into Csound before calling [`Csound::perform_ksmps`](struct.Csound.html#method.perform_ksmps)
@@ -658,7 +673,7 @@ impl Csound {
     /// Use [`Csound::get_spin`](struct.Csound.html#method.get_spin) to get a [`BufferPtr`](struct.BufferPtr.html)
     /// object.
     #[deprecated(since = "0.1.5", note = "please use Csound::get_spin object instead")]
-    pub fn write_spin_buffer(&self, input: &[f64]) -> Result<usize, &'static str> {
+    pub fn write_spin_buffer(&self, input: &[f64]) -> Result<usize> {
         let size = self.get_ksmps() as usize * self.get_channels(1) as usize;
         let spin = unsafe { csound_sys::csoundGetSpin(self.csound_ptr()) as *mut f64 };
         let mut len = input.len();
@@ -671,7 +686,9 @@ impl Csound {
                 return Ok(len);
             }
         }
-        Err("The spin buffer is not initialized, call the 'compile()' and 'start()' methods.")
+        Err(Error::BufferNotInitialized(
+            "spin buffer not initialized, call compile() and start() first",
+        ))
     }
 
     ///Calling this function after csoundCreate()
@@ -710,7 +727,7 @@ impl Csound {
                     device_id: Trampoline::ptr_to_string(dev.device_id.as_ptr()),
                     rt_module: Trampoline::ptr_to_string(dev.rt_module.as_ptr()),
                     max_nchnls: dev.max_nchnls as u32,
-                    isOutput: 0,
+                    is_output: 0,
                 });
             }
             for dev in &out_vec {
@@ -719,7 +736,7 @@ impl Csound {
                     device_id: Trampoline::ptr_to_string(dev.device_id.as_ptr()),
                     rt_module: Trampoline::ptr_to_string(dev.rt_module.as_ptr()),
                     max_nchnls: dev.max_nchnls as u32,
-                    isOutput: 1,
+                    is_output: 1,
                 });
             }
         }
@@ -731,10 +748,9 @@ impl Csound {
     /// Sets the current MIDI IO module
     pub fn set_midi_module(&self, name: &str) {
         unsafe {
-            let devName = CString::new(name);
-            if let Ok(dev) = devName {
-                let dev_name = dev;
-                csound_sys::csoundSetMIDIModule(self.csound_ptr(), dev_name.as_ptr());
+            let dev_name = CString::new(name);
+            if let Ok(dev) = dev_name {
+                csound_sys::csoundSetMIDIModule(self.csound_ptr(), dev.as_ptr());
             }
         }
     }
@@ -774,7 +790,7 @@ impl Csound {
                     device_id: Trampoline::ptr_to_string(dev.device_id.as_ptr()),
                     midi_module: Trampoline::ptr_to_string(dev.midi_module.as_ptr()),
                     interface_name: Trampoline::ptr_to_string(dev.interface_name.as_ptr()),
-                    isOutput: 0,
+                    is_output: 0,
                 });
             }
             for dev in &out_vec {
@@ -783,7 +799,7 @@ impl Csound {
                     device_id: Trampoline::ptr_to_string(dev.device_id.as_ptr()),
                     midi_module: Trampoline::ptr_to_string(dev.midi_module.as_ptr()),
                     interface_name: Trampoline::ptr_to_string(dev.interface_name.as_ptr()),
-                    isOutput: 1,
+                    is_output: 1,
                 });
             }
         }
@@ -796,12 +812,15 @@ impl Csound {
     /// Multiple events separated by newlines are possible
     /// and score preprocessing (carry, etc) is applied.
     /// Optionally run asynchronously (async = 1)
-    pub fn send_string_event(&self, string: &str, async_: i32) -> Result<(), &'static str> {
-        unsafe {
-            let s = Trampoline::convert_str_to_c(string)?;
-            csound_sys::csoundEventString(self.csound_ptr(), s.as_ptr(), async_);
-            Ok(())
+    pub fn send_string_event(&self, string: &str, async_: i32) -> Result<()> {
+        if string.is_empty() {
+            return Err(Error::EmptyString);
         }
+        let s = CString::new(string)?;
+        unsafe {
+            csound_sys::csoundEventString(self.csound_ptr(), s.as_ptr(), async_);
+        }
+        Ok(())
     }
 
     /// # Returns
@@ -1073,12 +1092,12 @@ impl Csound {
         unsafe {
             let result = Status::from(self.get_raw_channel_ptr(name, ptr, bits));
             match result {
-                Status::CS_SUCCESS => Ok(InputChannel {
+                Status::Success => Ok(InputChannel {
                     ptr: *ptr,
                     len,
                     phantom: PhantomData,
                 }),
-                Status::CS_OK(channel) => Err(Status::CS_OK(channel)),
+                Status::Ok(channel) => Err(Status::Ok(channel)),
                 result => Err(result),
             }
         }
@@ -1178,12 +1197,12 @@ impl Csound {
         unsafe {
             let result = Status::from(self.get_raw_channel_ptr(name, ptr, bits));
             match result {
-                Status::CS_SUCCESS => Ok(OutputChannel {
+                Status::Success => Ok(OutputChannel {
                     ptr: *ptr,
                     len,
                     phantom: PhantomData,
                 }),
-                Status::CS_OK(channel) => Err(Status::CS_OK(channel)),
+                Status::Ok(channel) => Err(Status::Ok(channel)),
                 result => Err(result),
             }
         }
@@ -1217,8 +1236,8 @@ impl Csound {
     /// channel. see: ([`Status`](enum.Status.html))
     pub fn set_channel_hints(&self, name: &str, hint: &ChannelHints) -> Result<(), Status> {
         let attr = &hint.attributes[..];
-        let attr = CString::new(attr).map_err(|_| Status::CS_ERROR)?;
-        let cname = CString::new(name).map_err(|_| Status::CS_ERROR)?;
+        let attr = CString::new(attr).map_err(|_| Status::Error)?;
+        let cname = CString::new(name).map_err(|_| Status::Error)?;
         let channel_hint = csound_sys::controlChannelHints_t {
             behav: ChannelBehavior::to_u32(&hint.behav),
             dflt: hint.dflt,
@@ -1237,7 +1256,7 @@ impl Csound {
                 channel_hint,
             ) as i32)
             {
-                Status::CS_SUCCESS => Ok(()),
+                Status::Success => Ok(()),
                 status => Err(status),
             }
         }
@@ -1247,7 +1266,7 @@ impl Csound {
     /// Previously set with csoundSetControlChannelHints() or the
     /// [chnparams](http://www.csounds.com/manualOLPC/chnparams.html) opcode.
     pub fn get_channel_hints(&self, name: &str) -> Result<ChannelHints, Status> {
-        let cname = CString::new(name).map_err(|_| Status::CS_ERROR)?;
+        let cname = CString::new(name).map_err(|_| Status::Error)?;
         let mut hint = csound_sys::controlChannelHints_t::default();
         unsafe {
             match csound_sys::csoundGetControlChannelHints(
@@ -1285,8 +1304,8 @@ impl Csound {
     /// * `name`  The channel name.
     /// An error message will be returned if the channel is not a control channel,
     /// the channel not exist or if the name is invalid.
-    pub fn get_control_channel(&self, name: &str) -> Result<f64, &'static str> {
-        let cname = CString::new(name).map_err(|_| "invalid channel name")?;
+    pub fn get_control_channel(&self, name: &str) -> Result<f64> {
+        let cname = CString::new(name)?;
         let mut err: c_int = 0;
         unsafe {
             let ret = csound_sys::csoundGetControlChannel(
@@ -1297,7 +1316,9 @@ impl Csound {
             if (err) == CSOUND_STATUS::CSOUND_SUCCESS {
                 Ok(ret)
             } else {
-                Err("channel not exist or is not a control channel")
+                Err(Error::NotFound(
+                    "channel does not exist or is not a control channel",
+                ))
             }
         }
     }
@@ -1411,20 +1432,15 @@ impl Csound {
     ///     cs.send_sound_event(0, &pFields, 0);
     /// }
     /// ```
-    pub fn send_sound_event(
-        &self,
-        event_type: i32,
-        pfields: &[f64],
-        async_: i32,
-    ) -> Result<(), &'static str> {
+    pub fn send_sound_event(&self, event_type: i32, pfields: &[f64], async_: i32) {
         unsafe {
-            Ok(csound_sys::csoundEvent(
+            csound_sys::csoundEvent(
                 self.csound_ptr(),
                 event_type,
                 pfields.as_ptr() as *mut c_double,
                 pfields.len() as c_int,
                 async_,
-            ))
+            );
         }
     }
 
@@ -1443,13 +1459,13 @@ impl Csound {
     /// message if the table doens't exist.
     /// # Arguments
     /// * `table` The function table identifier.
-    pub fn table_length(&self, table: u32) -> Result<usize, &'static str> {
+    pub fn table_length(&self, table: u32) -> Result<usize> {
         unsafe {
             let value = csound_sys::csoundTableLength(self.csound_ptr(), table as c_int) as i32;
             if value > 0 {
                 Ok(value as usize)
             } else {
-                Err("Table doesn't exist")
+                Err(Error::NotFound("table does not exist"))
             }
         }
     }
@@ -1595,7 +1611,7 @@ impl Csound {
     /// * `lang_code` can be for example any of [`Language`](enum.Language.html) variants.
     /// This affects all Csound instances running in the address
     /// space of the current process. The special language code
-    /// *Language::CSLANGUAGE_DEFAULT* can be used to disable translation of messages and
+    /// *Language::Default* can be used to disable translation of messages and
     /// free all memory allocated by a previous call to this function.
     /// set_language() loads all files for the selected language from the directory specified by the **CSSTRNGS** environment
     /// variable.
@@ -1617,7 +1633,7 @@ impl Csound {
     /// The next number from the pseudo-random sequence, in the range 1 to 2147483646.
     /// if the value of seed is not in the range 1 to 2147483646 an error message will
     /// be returned.
-    pub fn get_rand31(seed: &mut u32) -> Result<u32, &'static str> {
+    pub fn get_rand31(seed: &mut u32) -> Result<u32> {
         unsafe {
             match seed {
                 1..=2_147_483_646 => {
@@ -1625,7 +1641,7 @@ impl Csound {
                     let res = csound_sys::csoundRand31(ptr as *mut c_int) as u32;
                     Ok(res)
                 }
-                _ => Err("invalid seed value"),
+                _ => Err(Error::InvalidSeed),
             }
         }
     }
@@ -1733,7 +1749,7 @@ impl Csound {
 
     /// Sets a function to be called by Csound for opening real-time audio recording.
     /// This callback is used to inform the user about the current audio device Which
-    /// Csound will use for opening realtime audio recording. You have to return Status::CS_SUCCESS
+    /// Csound will use for opening realtime audio recording. You have to return Status::Success
     pub fn rec_open_audio_callback<'c, F>(&self, f: F)
     where
         F: FnMut(&RtAudioParams) -> Status + 'c,
@@ -1827,7 +1843,7 @@ impl Csound {
     /// # Arguments
     /// * ´f´ Function which implement the FnMut trait. The invalue opcode will trigger this callback passing
     /// the channel name which requiere the data. This function/closure have to return the data which will be
-    /// passed to that specific channel if not only return ChannelData::CS_UNKNOWN_CHANNEL. Only *String* and *control* Channels
+    /// passed to that specific channel if not only return ChannelData::Unknown. Only *String* and *control* Channels
     /// are supported.
     /// # Example
     /// ```
@@ -1836,9 +1852,9 @@ impl Csound {
     /// let input_channel = |name: &str| -> ChannelData {
     ///      if name == "myStringChannel"{
     ///          let myString = "my data".to_owned();
-    ///          ChannelData::CS_STRING_CHANNEL(myString);
+    ///          ChannelData::String(myString);
     ///      }
-    ///      ChannelData::CS_UNKNOWN_CHANNEL
+    ///      ChannelData::Unknown
     /// };
     /// let mut cs = Csound::new().unwrap();
     /// cs.input_channel_callback(input_channel);
@@ -2048,9 +2064,9 @@ where
     /// # Returns
     /// The number of items read **(0 <= n <= items)**.
     /// or an Error if the output buffer doesn't have enough capacity.
-    pub fn read(&self, out: &mut [T], items: u32) -> Result<usize, &'static str> {
-        if items as usize <= out.len() {
-            return Err("your buffer has not enough capacity");
+    pub fn read(&self, out: &mut [T], items: u32) -> Result<usize> {
+        if (items as usize) > out.len() {
+            return Err(Error::InsufficientCapacity);
         }
         unsafe {
             Ok(csound_sys::csoundReadCircularBuffer(
@@ -2069,9 +2085,9 @@ where
     /// # Returns
     /// The actual number of items read **(0 <= n <= items)**, or an error if the number of items
     /// to read/write exceeds the buffer's capacity.
-    pub fn peek(&self, out: &mut [T], items: u32) -> Result<usize, &'static str> {
-        if items as usize <= out.len() {
-            return Err("your buffer has not enough capacity");
+    pub fn peek(&self, out: &mut [T], items: u32) -> Result<usize> {
+        if (items as usize) > out.len() {
+            return Err(Error::InsufficientCapacity);
         }
         unsafe {
             Ok(csound_sys::csoundPeekCircularBuffer(
@@ -2090,9 +2106,9 @@ where
     /// # Returns
     /// The actual number of items written *(0 <= n <= items)**, or an error if the number of items
     /// to read/write exceeds the buffer's capacity.
-    pub fn write(&self, input: &[T], items: u32) -> Result<usize, &'static str> {
-        if items as usize <= input.len() {
-            return Err("your buffer has not enough capacity");
+    pub fn write(&self, input: &[T], items: u32) -> Result<usize> {
+        if (items as usize) > input.len() {
+            return Err(Error::InsufficientCapacity);
         }
         unsafe {
             Ok(csound_sys::csoundWriteCircularBuffer(

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types)]
-
 use bitflags::bitflags;
 use std::mem::transmute;
 
@@ -16,76 +14,65 @@ pub enum ControlChannel {}
 pub enum StrChannel {}
 
 /// Define the type of csound messages
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum MessageType {
-    /// standard message.
-    CSOUNDMSG_DEFAULT,
-
-    /// error message (initerror, perferror, etc.).
-    CSOUNDMSG_ERROR,
-
-    /// orchestra opcodes (e.g. printks).
-    CSOUNDMSG_ORCH,
-
-    /// for progress display and heartbeat characters.
-    CSOUNDMSG_REALTIME,
-
-    /// warning messages.
-    CSOUNDMSG_WARNING,
-
-    /// stdout messages.
-    CSOUNDMSG_STDOUT,
+    /// Standard message.
+    Default,
+    /// Error message (initerror, perferror, etc.).
+    Error,
+    /// Orchestra opcodes (e.g. printks).
+    Orch,
+    /// Progress display and heartbeat characters.
+    Realtime,
+    /// Warning messages.
+    Warning,
+    /// Stdout messages.
+    Stdout,
 }
 
 impl From<u32> for MessageType {
     fn from(value: u32) -> Self {
         match value {
-            0x0000 => MessageType::CSOUNDMSG_DEFAULT,
-            0x1000 => MessageType::CSOUNDMSG_ERROR,
-            0x2000 => MessageType::CSOUNDMSG_ORCH,
-            0x3000 => MessageType::CSOUNDMSG_REALTIME,
-            0x4000 => MessageType::CSOUNDMSG_WARNING,
-            0x5000 => MessageType::CSOUNDMSG_STDOUT,
-            _ => MessageType::CSOUNDMSG_ERROR,
+            0x0000 => MessageType::Default,
+            0x1000 => MessageType::Error,
+            0x2000 => MessageType::Orch,
+            0x3000 => MessageType::Realtime,
+            0x4000 => MessageType::Warning,
+            0x5000 => MessageType::Stdout,
+            _ => MessageType::Error,
         }
     }
 }
 
 /// Csound error codes
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
 pub enum Status {
     /// Termination requested by SIGINT or SIGTERM.
-    CS_SIGNAL,
-
+    Signal,
     /// Failed to allocate requested memory.
-    CS_MEMORY,
-
+    Memory,
     /// Failed during performance.
-    CS_PERFORMANCE,
-
+    Performance,
     /// Failed during initialization.
-    CS_INITIALIZATION,
-
+    Initialization,
     /// Unspecified failure.
-    CS_ERROR,
-
+    Error,
     /// Completed successfully.
-    CS_SUCCESS,
-
+    Success,
     /// Completed but with additional info.
-    CS_OK(i32),
+    Ok(i32),
 }
 
 impl From<i32> for Status {
     fn from(value: i32) -> Self {
         match value {
-            -5 => Status::CS_SIGNAL,
-            -4 => Status::CS_MEMORY,
-            -3 => Status::CS_PERFORMANCE,
-            -2 => Status::CS_INITIALIZATION,
-            -1 => Status::CS_ERROR,
-            0 => Status::CS_SUCCESS,
-            value => Status::CS_OK(value),
+            -5 => Status::Signal,
+            -4 => Status::Memory,
+            -3 => Status::Performance,
+            -2 => Status::Initialization,
+            -1 => Status::Error,
+            0 => Status::Success,
+            value => Status::Ok(value),
         }
     }
 }
@@ -93,26 +80,29 @@ impl From<i32> for Status {
 impl Status {
     pub fn to_i32(&self) -> i32 {
         match self {
-            Status::CS_SIGNAL => -5,
-            Status::CS_MEMORY => -4,
-            Status::CS_PERFORMANCE => -3,
-            Status::CS_INITIALIZATION => -2,
-            Status::CS_ERROR => -1,
-            Status::CS_SUCCESS => 0,
-            Status::CS_OK(value) => *value,
+            Status::Signal => -5,
+            Status::Memory => -4,
+            Status::Performance => -3,
+            Status::Initialization => -2,
+            Status::Error => -1,
+            Status::Success => 0,
+            Status::Ok(value) => *value,
         }
     }
 }
 
 /// Enum variant which represent channel's types in callbacks.
 ///
-/// Channels which could trigger a callback, that is, channels created using  the [*invalue*](http://www.csounds.com/manual/html/invalue.html),
+/// Channels which could trigger a callback, that is, channels created using the [*invalue*](http://www.csounds.com/manual/html/invalue.html),
 /// [*outvalue*](http://www.csounds.com/manual/html/outvalue.html) opcodes. Only control and string channels are supported.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChannelData {
-    CS_CONTROL_CHANNEL(f64),
-    CS_STRING_CHANNEL(String),
-    CS_UNKNOWN_CHANNEL,
+    /// Control channel data (single f64 value).
+    Control(f64),
+    /// String channel data.
+    String(String),
+    /// Unknown channel type.
+    Unknown,
 }
 
 bitflags! {

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,26 @@ pub enum Error {
     #[error("invalid argument: {0}")]
     InvalidArgument(&'static str),
 
+    /// Csound is already started.
+    #[error("csound is already started, call reset() before starting again")]
+    AlreadyStarted,
+
+    /// An internal buffer has not been initialized.
+    #[error("buffer not initialized: {0}")]
+    BufferNotInitialized(&'static str),
+
+    /// An empty string was provided where content was expected.
+    #[error("empty string provided")]
+    EmptyString,
+
+    /// An invalid seed value was provided.
+    #[error("invalid seed value: must be in range 1..=2147483646")]
+    InvalidSeed,
+
+    /// Insufficient buffer capacity for the requested operation.
+    #[error("insufficient buffer capacity")]
+    InsufficientCapacity,
+
     // Flattened from Status - csound C API error codes
     /// Termination requested by SIGINT or SIGTERM.
     #[error("termination requested by signal")]
@@ -78,13 +98,13 @@ impl Status {
     /// and error variants to Err.
     pub fn into_result(self) -> Result<CsoundStatus, Error> {
         match self {
-            Status::CS_SUCCESS => Ok(CsoundStatus::Success),
-            Status::CS_OK(v) => Ok(CsoundStatus::Done(v)),
-            Status::CS_SIGNAL => Err(Error::Signal),
-            Status::CS_MEMORY => Err(Error::Memory),
-            Status::CS_PERFORMANCE => Err(Error::Performance),
-            Status::CS_INITIALIZATION => Err(Error::Initialization),
-            Status::CS_ERROR => Err(Error::OperationFailed),
+            Status::Success => Ok(CsoundStatus::Success),
+            Status::Ok(v) => Ok(CsoundStatus::Done(v)),
+            Status::Signal => Err(Error::Signal),
+            Status::Memory => Err(Error::Memory),
+            Status::Performance => Err(Error::Performance),
+            Status::Initialization => Err(Error::Initialization),
+            Status::Error => Err(Error::OperationFailed),
         }
     }
 }

--- a/src/rtaudio.rs
+++ b/src/rtaudio.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-
 use std::fmt;
 
 /// Struct with specific audio device information.
@@ -9,7 +7,7 @@ pub struct CsAudioDevice {
     pub device_id: Option<String>,
     pub rt_module: Option<String>,
     pub max_nchnls: u32,
-    pub isOutput: u32,
+    pub is_output: u32,
 }
 
 /// Struct with specific MIDI device information.
@@ -19,7 +17,7 @@ pub struct CsMidiDevice {
     pub interface_name: Option<String>,
     pub device_id: Option<String>,
     pub midi_module: Option<String>,
-    pub isOutput: u32,
+    pub is_output: u32,
 }
 
 impl fmt::Debug for CsMidiDevice {
@@ -29,7 +27,7 @@ impl fmt::Debug for CsMidiDevice {
             .field("interface_name", &self.interface_name)
             .field("device_id", &self.device_id)
             .field("midi_module", &self.midi_module)
-            .field("isOutput", &self.isOutput)
+            .field("is_output", &self.is_output)
             .finish()
     }
 }
@@ -41,7 +39,7 @@ impl fmt::Debug for CsAudioDevice {
             .field("device_id", &self.device_id)
             .field("rt_module", &self.rt_module)
             .field("max_nchnls", &self.max_nchnls)
-            .field("isOutput", &self.isOutput)
+            .field("is_output", &self.is_output)
             .finish()
     }
 }
@@ -51,17 +49,17 @@ impl fmt::Debug for CsAudioDevice {
 #[derive(Debug, Clone, Default)]
 pub struct RtAudioParams {
     /// Device Name.
-    pub devName: Option<String>,
+    pub dev_name: Option<String>,
     /// Device number.
-    pub devNum: u32,
+    pub dev_num: u32,
     /// Device software buffer size.
-    pub bufSamp_SW: u32,
+    pub buf_samp_sw: u32,
     /// Device hardware buffer size.
-    pub bufSamp_HW: u32,
+    pub buf_samp_hw: u32,
     /// Device max number of channels supported.
-    pub nChannels: u32,
+    pub n_channels: u32,
     /// Device audio sample format.
-    pub sampleFormat: u32,
+    pub sample_format: u32,
     /// Device max sample rate.
-    pub sampleRate: f32,
+    pub sample_rate: f32,
 }


### PR DESCRIPTION
…ions

BREAKING CHANGES:
- Enum variants renamed to idiomatic Rust style (PascalCase without prefixes)
- Struct fields renamed to snake_case
- ChannelData variants: CS_CONTROL_CHANNEL -> Control, CS_STRING_CHANNEL -> String
- Status variants: CS_SUCCESS -> Success, CS_ERROR -> Error, etc.
- MessageType variants: CSOUNDMSG_DEFAULT -> Default, CSOUNDMSG_ERROR -> Error, etc.

Improvements:
- Migrate to Rust Edition 2024
- Use NonNull<T> for FFI pointers instead of raw pointers
- Use OnceLock for thread-safe one-time initialization
- Remove Interior mutability (RefCell) from Inner struct
- Make Inner implement Send safely
- Flatten Status error variants into the Error enum
- Remove #![allow(non_snake_case)] attributes

Struct field renames (snake_case):
- CsAudioDevice/CsMidiDevice: isOutput -> is_output
- RtAudioParams: devName -> dev_name, devNum -> dev_num, bufSamp_SW -> buf_samp_sw, bufSamp_HW -> buf_samp_hw, nChannels -> n_channels, sampleFormat -> sample_format, sampleRate -> sample_rate
- PvsDataExt: N -> n, NB -> nb