### PR TITLE
refactor!: modernize enums and channel API with Rust conventions

### DIFF
--- a/examples/src/example10.rs
+++ b/examples/src/example10.rs
@@ -22,7 +22,6 @@
  * to illustrate the concept.
  */
 
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
 use csound::{ControlChannel, Csound, InputChannel};
 use rand;
 
@@ -54,7 +53,7 @@ impl<'a, T: RandomFunc> Updater<'a, T> {
     }
 
     fn update(&mut self) {
-        *self.channel = self.data.update();
+        self.channel.set(self.data.update());
     }
 }
 

--- a/examples/src/example7.rs
+++ b/examples/src/example7.rs
@@ -22,12 +22,11 @@
  * gets us the current value, but also advances the internal state by the
  * increment and by decrementing the duration.
  */
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
 use csound::*;
 use rand;
 
 #[derive(Default)]
-pub struct random_line {
+pub struct RandomLine {
     dur: i32,
     end: f64,
     increment: f64,
@@ -36,31 +35,35 @@ pub struct random_line {
     range: f64,
 }
 
-/* Resets a random_line by calculating new end, dur, and increment values */
-fn random_line_reset(rline: &mut random_line) {
-    rline.dur = (rand::random::<i32>() % 256) + 256;
-    rline.end = rand::random::<f64>(); // check
-    rline.increment = (rline.end - rline.current_val) / (rline.dur as f64);
-}
-
-/* Creates a random_line and initializes values */
-pub fn random_line_create(base: f64, range: f64) -> random_line {
-    let mut retval = random_line::default();
-    retval.base = base;
-    retval.range = range;
-    random_line_reset(&mut retval);
-    retval
-}
-
-/* Advances state of random line and returns current value */
-fn random_line_tick(rline: &mut random_line) -> f64 {
-    let current_value = rline.current_val;
-    rline.dur -= 1;
-    if rline.dur <= 0 {
-        random_line_reset(rline);
+impl RandomLine {
+    /// Creates a RandomLine and initializes values
+    pub fn new(base: f64, range: f64) -> RandomLine {
+        let mut line = RandomLine {
+            base,
+            range,
+            ..Default::default()
+        };
+        line.reset();
+        line
     }
-    rline.current_val += rline.increment;
-    rline.base + (current_value * rline.range)
+
+    /// Resets by calculating new end, dur, and increment values
+    fn reset(&mut self) {
+        self.dur = (rand::random::<i32>() % 256) + 256;
+        self.end = rand::random::<f64>();
+        self.increment = (self.end - self.current_val) / (self.dur as f64);
+    }
+
+    /// Advances state and returns current value
+    fn tick(&mut self) -> f64 {
+        let current_value = self.current_val;
+        self.dur -= 1;
+        if self.dur <= 0 {
+            self.reset();
+        }
+        self.current_val += self.increment;
+        self.base + (current_value * self.range)
+    }
 }
 
 /* Defining our Csound ORC code within a multiline String */
@@ -81,38 +84,30 @@ endin";
 fn main() {
     let mut cs = Csound::new().expect("Failed to create Csound instance");
 
-    /* Using SetOption() to configure Csound
-    Note: use only one commandline flag at a time */
+    // Using SetOption() to configure Csound
+    // Note: use only one commandline flag at a time
     cs.set_option("-odac").unwrap();
 
-    /* Compile the Csound Orchestra string */
+    // Compile the Csound Orchestra string
     cs.compile_orc(ORC, 0).unwrap();
 
-    /* Compile the Csound SCO String */
+    // Compile the Csound SCO String
     cs.send_string_event("i1 0 60", 0).unwrap();
 
-    /* When compiling from strings, this call is necessary
-     * before doing any performing */
+    // When compiling from strings, this call is necessary before performing
     cs.start().unwrap();
 
-    /* Create a random_line for use with Amplitude */
-    let mut amp = random_line_create(0.4, 0.2);
+    // Create RandomLines for amplitude and frequency
+    let mut amp = RandomLine::new(0.4, 0.2);
+    let mut freq = RandomLine::new(400.0, 80.0);
 
-    /* Create a random_line for use with Frequency */
-    let mut freq = random_line_create(400.0, 80.0);
+    // Initialize channel values before running Csound
+    cs.set_control_channel("amp", amp.tick());
+    cs.set_control_channel("freq", freq.tick());
 
-    /* Initialize channel values before running Csound */
-    cs.set_control_channel("amp", random_line_tick(&mut amp));
-    cs.set_control_channel("freq", random_line_tick(&mut freq));
-
-    /* The following is our main performance loop. We will perform one
-     * block of sound at a time and continue to do so while it returns false,
-     * which signifies to keep processing.  We will explore this loop
-     * technique in further examples.
-     */
+    // Main performance loop - perform one block at a time
     while !cs.perform_ksmps() {
-        /* Update Channel Values */
-        cs.set_control_channel("amp", random_line_tick(&mut amp));
-        cs.set_control_channel("freq", random_line_tick(&mut freq));
+        cs.set_control_channel("amp", amp.tick());
+        cs.set_control_channel("freq", freq.tick());
     }
 }

--- a/examples/src/example8.rs
+++ b/examples/src/example8.rs
@@ -19,13 +19,11 @@
  *
  */
 
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-
 use csound::{ControlChannel, Csound};
 use rand;
 
 #[derive(Default)]
-pub struct random_line {
+pub struct RandomLine {
     dur: i32,
     end: f64,
     increment: f64,
@@ -34,31 +32,35 @@ pub struct random_line {
     range: f64,
 }
 
-/* Resets a random_line by calculating new end, dur, and increment values */
-fn random_line_reset(rline: &mut random_line) {
-    rline.dur = (rand::random::<i32>() % 256) + 256;
-    rline.end = rand::random::<f64>();
-    rline.increment = (rline.end - rline.current_val) / (rline.dur as f64);
-}
-
-/* Creates a random_line and initializes values */
-pub fn random_line_create(base: f64, range: f64) -> random_line {
-    let mut retval = random_line::default();
-    retval.base = base;
-    retval.range = range;
-    random_line_reset(&mut retval);
-    retval
-}
-
-/* Advances state of random line and returns current value */
-fn random_line_tick(rline: &mut random_line) -> f64 {
-    let current_value = rline.current_val;
-    rline.dur -= 1;
-    if rline.dur <= 0 {
-        random_line_reset(rline);
+impl RandomLine {
+    /// Creates a RandomLine and initializes values
+    pub fn new(base: f64, range: f64) -> RandomLine {
+        let mut line = RandomLine {
+            base,
+            range,
+            ..Default::default()
+        };
+        line.reset();
+        line
     }
-    rline.current_val += rline.increment;
-    rline.base + (current_value * rline.range)
+
+    /// Resets by calculating new end, dur, and increment values
+    fn reset(&mut self) {
+        self.dur = (rand::random::<i32>() % 256) + 256;
+        self.end = rand::random::<f64>();
+        self.increment = (self.end - self.current_val) / (self.dur as f64);
+    }
+
+    /// Advances state and returns current value
+    fn tick(&mut self) -> f64 {
+        let current_value = self.current_val;
+        self.dur -= 1;
+        if self.dur <= 0 {
+            self.reset();
+        }
+        self.current_val += self.increment;
+        self.base + (current_value * self.range)
+    }
 }
 
 /* Defining our Csound ORC code within a multiline String */
@@ -79,40 +81,30 @@ endin";
 fn main() {
     let cs = Csound::new().expect("Failed to create Csound instance");
 
-    /* Using SetOption() to configure Csound
-    Note: use only one commandline flag at a time */
+    // Using SetOption() to configure Csound
+    // Note: use only one commandline flag at a time
     cs.set_option("-odac").unwrap();
 
-    /* Compile the Csound Orchestra string */
+    // Compile the Csound Orchestra string
     cs.compile_orc(ORC, 0).unwrap();
 
-    /* Compile the Csound SCO String */
+    // Compile the Csound SCO String
     cs.send_string_event("i1 0 60", 0).unwrap();
 
-    /* When compiling from strings, this call is necessary
-     * before doing any performing */
+    // When compiling from strings, this call is necessary before performing
     cs.start().unwrap();
 
-    /* Create a random_line for use with Amplitude */
-    let mut amp = random_line_create(0.4, 0.2);
+    // Create RandomLines for amplitude and frequency
+    let mut amp = RandomLine::new(0.4, 0.2);
+    let mut freq = RandomLine::new(400.0, 80.0);
 
-    /* Create a random_line for use with Frequency */
-    let mut freq = random_line_create(400.0, 80.0);
-
-    /* Retrieve Channel Pointers from Csound */
+    // Retrieve Channel Pointers from Csound
     let amp_channel = cs.get_input_channel::<ControlChannel>("amp").unwrap();
     let freq_channel = cs.get_input_channel::<ControlChannel>("freq").unwrap();
 
-    /* Initialize channel values before running Csound */
-
-    /* The following is our main performance loop. We will perform one
-     * block of sound at a time and continue to do so while it returns false,
-     * which signifies to keep processing.  We will explore this loop
-     * technique in further examples.
-     */
+    // Main performance loop - perform one block at a time
     while !cs.perform_ksmps() {
-        /* Update Channel Values */
-        amp_channel.write(random_line_tick(&mut amp));
-        freq_channel.write(random_line_tick(&mut freq));
+        amp_channel.write(amp.tick());
+        freq_channel.write(freq.tick());
     }
 }

--- a/examples/src/example9.rs
+++ b/examples/src/example9.rs
@@ -11,12 +11,11 @@
  *
  */
 
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
 use csound::{ControlChannel, Csound, InputChannel};
 use rand;
 
 #[derive(Default)]
-pub struct random_line {
+pub struct RandomLine {
     dur: i32,
     end: f64,
     increment: f64,
@@ -25,38 +24,41 @@ pub struct random_line {
     range: f64,
 }
 
-/* Resets a random_line by calculating new end, dur, and increment values */
-fn random_line_reset(rline: &mut random_line) {
-    rline.dur = (rand::random::<i32>() % 256) + 256;
-    rline.end = rand::random::<f64>();
-    rline.increment = (rline.end - rline.current_val) / (rline.dur as f64);
-}
-
-/* Creates a random_line and initializes values */
-pub fn random_line_create(base: f64, range: f64) -> random_line {
-    let mut retval = random_line::default();
-    retval.base = base;
-    retval.range = range;
-    random_line_reset(&mut retval);
-    retval
-}
-
-/* Advances state of random line and returns current value */
-fn random_line_tick(rline: &mut random_line) -> f64 {
-    let current_value = rline.current_val;
-    rline.dur -= 1;
-    if rline.dur <= 0 {
-        random_line_reset(rline);
+impl RandomLine {
+    /// Creates a RandomLine and initializes values
+    pub fn new(base: f64, range: f64) -> RandomLine {
+        let mut line = RandomLine {
+            base,
+            range,
+            ..Default::default()
+        };
+        line.reset();
+        line
     }
-    rline.current_val += rline.increment;
-    rline.base + (current_value * rline.range)
+
+    /// Resets by calculating new end, dur, and increment values
+    fn reset(&mut self) {
+        self.dur = (rand::random::<i32>() % 256) + 256;
+        self.end = rand::random::<f64>();
+        self.increment = (self.end - self.current_val) / (self.dur as f64);
+    }
+
+    /// Advances state and returns current value
+    fn tick(&mut self) -> f64 {
+        let current_value = self.current_val;
+        self.dur -= 1;
+        if self.dur <= 0 {
+            self.reset();
+        }
+        self.current_val += self.increment;
+        self.base + (current_value * self.range)
+    }
 }
 
 fn create_channel<'a>(csound: &'a Csound, channel_name: &str) -> InputChannel<'a, ControlChannel> {
-    match csound.get_input_channel::<ControlChannel>(channel_name) {
-        Ok(ptr) => ptr,
-        Err(status) => panic!("Channel not exists {:?}", status),
-    }
+    csound
+        .get_input_channel::<ControlChannel>(channel_name)
+        .expect("Channel does not exist")
 }
 
 /* Defining our Csound ORC code within a multiline String */
@@ -77,38 +79,30 @@ endin";
 fn main() {
     let cs = Csound::new().expect("Failed to create Csound instance");
 
-    /* Using SetOption() to configure Csound
-    Note: use only one commandline flag at a time */
+    // Using SetOption() to configure Csound
+    // Note: use only one commandline flag at a time
     cs.set_option("-odac").unwrap();
 
-    /* Compile the Csound Orchestra string */
+    // Compile the Csound Orchestra string
     cs.compile_orc(ORC, 0).unwrap();
 
-    /* Compile the Csound SCO String */
+    // Compile the Csound SCO String
     cs.send_string_event("i1 0 60", 0).unwrap();
 
-    /* When compiling from strings, this call is necessary
-     * before doing any performing */
+    // When compiling from strings, this call is necessary before performing
     cs.start().unwrap();
 
-    /* Create a random_line for use with Amplitude */
-    let mut amp = random_line_create(0.4, 0.2);
+    // Create RandomLines for amplitude and frequency
+    let mut amp = RandomLine::new(0.4, 0.2);
+    let mut freq = RandomLine::new(400.0, 80.0);
 
-    /* Create a random_line for use with Frequency */
-    let mut freq = random_line_create(400.0, 80.0);
-
-    /* Retrieve Channel Pointers from Csound */
+    // Retrieve Channel Pointers from Csound
     let amp_channel = create_channel(&cs, "amp");
     let freq_channel = create_channel(&cs, "freq");
 
-    /* The following is our main performance loop. We will perform one
-     * block of sound at a time and continue to do so while it returns false,
-     * which signifies to keep processing.  We will explore this loop
-     * technique in further examples.
-     */
+    // Main performance loop - perform one block at a time
     while !cs.perform_ksmps() {
-        /* Update Channel Values */
-        amp_channel.write(random_line_tick(&mut amp));
-        freq_channel.write(random_line_tick(&mut freq));
+        amp_channel.write(amp.tick());
+        freq_channel.write(freq.tick());
     }
 }

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
 use std::slice;
 
 use crate::enums::{AudioChannel, ControlChannel, ControlChannelType, StrChannel};
@@ -126,20 +126,85 @@ impl PvsDataExt {
     }
 }
 
-/// Struct represents a csound input channel object.
+/// Csound input channel - allows writing data to csound.
+///
+/// This struct wraps a pointer to csound's internal channel buffer.
+/// Use the explicit `get()`, `set()`, `write()`, and slice accessor methods
+/// rather than relying on implicit dereferencing.
 #[derive(Debug)]
 pub struct InputChannel<'a, T> {
-    pub(crate) ptr: *mut f64,
-    pub(crate) len: usize,
-    pub(crate) phantom: PhantomData<&'a mut T>,
+    ptr: NonNull<f64>,
+    len: usize,
+    phantom: PhantomData<&'a mut T>,
 }
 
-/// Struct represents a csound output channel object.
+/// Csound output channel - allows reading data from csound.
+///
+/// This struct wraps a pointer to csound's internal channel buffer.
+/// Use the explicit `get()`, `read()`, and slice accessor methods
+/// rather than relying on implicit dereferencing.
 #[derive(Debug)]
 pub struct OutputChannel<'a, T> {
-    pub(crate) ptr: *mut f64,
-    pub(crate) len: usize,
-    pub(crate) phantom: PhantomData<&'a T>,
+    ptr: NonNull<f64>,
+    len: usize,
+    phantom: PhantomData<&'a T>,
+}
+
+// SAFETY: Channel pointers are tied to the Csound instance lifetime
+// and access is synchronized through csound's own mechanisms.
+unsafe impl<T> Send for InputChannel<'_, T> {}
+unsafe impl<T> Send for OutputChannel<'_, T> {}
+
+impl<'a, T> InputChannel<'a, T> {
+    /// Creates a new InputChannel from a raw pointer.
+    ///
+    /// # Safety
+    /// The pointer must be valid and point to memory owned by csound.
+    pub(crate) unsafe fn from_raw(ptr: *mut f64, len: usize) -> Option<Self> {
+        NonNull::new(ptr).map(|ptr| InputChannel {
+            ptr,
+            len,
+            phantom: PhantomData,
+        })
+    }
+
+    /// Returns the length of the channel buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the channel buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl<'a, T> OutputChannel<'a, T> {
+    /// Creates a new OutputChannel from a raw pointer.
+    ///
+    /// # Safety
+    /// The pointer must be valid and point to memory owned by csound.
+    pub(crate) unsafe fn from_raw(ptr: *mut f64, len: usize) -> Option<Self> {
+        NonNull::new(ptr).map(|ptr| OutputChannel {
+            ptr,
+            len,
+            phantom: PhantomData,
+        })
+    }
+
+    /// Returns the length of the channel buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the channel buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 pub trait IsChannel {
@@ -148,210 +213,161 @@ pub trait IsChannel {
 
 impl IsChannel for ControlChannel {
     fn c_type() -> ControlChannelType {
-        ControlChannelType::CSOUND_CONTROL_CHANNEL
+        ControlChannelType::Control
     }
 }
+
 impl IsChannel for AudioChannel {
     fn c_type() -> ControlChannelType {
-        ControlChannelType::CSOUND_AUDIO_CHANNEL
+        ControlChannelType::Audio
     }
 }
+
 impl IsChannel for StrChannel {
     fn c_type() -> ControlChannelType {
-        ControlChannelType::CSOUND_STRING_CHANNEL
+        ControlChannelType::String
     }
 }
 
-// CONTROL CHANNEL
-impl<'a> OutputChannel<'a, ControlChannel> {
-    /// Reads data from a csound's control channel
-    ///
-    /// # Returns
-    /// A reference to the control channel's value
-    pub fn read(&'a self) -> f64 {
-        unsafe { *self.ptr }
-    }
-}
+// ============================================================================
+// CONTROL CHANNEL implementations
+// ============================================================================
 
 impl<'a> InputChannel<'a, ControlChannel> {
-    /// Writes data to csound's control channel
-    pub fn write(&self, inp: f64) {
+    /// Gets the current value of the control channel.
+    #[inline]
+    pub fn get(&self) -> f64 {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { *self.ptr.as_ptr() }
+    }
+
+    /// Sets the value of the control channel.
+    #[inline]
+    pub fn set(&self, value: f64) {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
-            *self.ptr = inp;
+            *self.ptr.as_ptr() = value;
         }
+    }
+
+    /// Writes a value to the control channel (alias for `set`).
+    #[inline]
+    pub fn write(&self, value: f64) {
+        self.set(value);
     }
 }
 
-// AUDIO CHANNEL
-impl<'a> OutputChannel<'a, AudioChannel> {
-    /// Reads data from a csound's Audio channel
-    ///
-    /// # Returns
-    /// A reference to the control channel's slice of ksmps samples
-    pub fn read(&'a self) -> &'a [f64] {
-        unsafe { slice::from_raw_parts(self.ptr as *const f64, self.len) }
+impl<'a> OutputChannel<'a, ControlChannel> {
+    /// Gets the current value of the control channel.
+    #[inline]
+    pub fn get(&self) -> f64 {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { *self.ptr.as_ptr() }
+    }
+
+    /// Reads the value from the control channel (alias for `get`).
+    #[inline]
+    pub fn read(&self) -> f64 {
+        self.get()
     }
 }
+
+// ============================================================================
+// AUDIO CHANNEL implementations
+// ============================================================================
 
 impl<'a> InputChannel<'a, AudioChannel> {
-    /// Writes audio data to an audio channel
+    /// Returns an immutable slice of the audio channel's samples.
+    #[inline]
+    pub fn as_slice(&self) -> &[f64] {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Returns a mutable slice of the audio channel's samples.
     ///
-    /// # Arguments
-    /// A slice of ksmps audio samples to be copied into the channel's buffer
-    /// If this slice is longer than the channel's buffer, only
-    /// Channel's size elements would be copied
-    pub fn write(&self, inp: &[f64]) {
-        let mut len = inp.len();
-        let size = self.len;
-        if size < len {
-            len = size;
-        }
+    /// # Safety
+    /// Caller must ensure no aliasing occurs with csound's internal access.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [f64] {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Writes audio samples to the channel.
+    ///
+    /// If the input slice is longer than the channel buffer,
+    /// only `len()` samples will be copied.
+    pub fn write(&self, samples: &[f64]) {
+        let copy_len = samples.len().min(self.len);
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
-            std::ptr::copy(inp.as_ptr(), self.ptr, len);
+            std::ptr::copy_nonoverlapping(samples.as_ptr(), self.ptr.as_ptr(), copy_len);
         }
     }
 }
 
-// STRING CHANNEL
-impl<'a> OutputChannel<'a, StrChannel> {
-    /// Reads data from a csound's Audio channel
-    ///
-    /// # Returns
-    /// A reference to the string channel's slice with bytes which represents the content of a string channel
-    pub fn read(&'a self) -> &'a [u8] {
-        unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
+impl<'a> OutputChannel<'a, AudioChannel> {
+    /// Returns an immutable slice of the audio channel's samples.
+    #[inline]
+    pub fn as_slice(&self) -> &[f64] {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Reads the audio samples from the channel (alias for `as_slice`).
+    #[inline]
+    pub fn read(&self) -> &[f64] {
+        self.as_slice()
     }
 }
+
+// ============================================================================
+// STRING CHANNEL implementations
+// ============================================================================
 
 impl<'a> InputChannel<'a, StrChannel> {
-    /// Writes bytes to a string channel's buffer
+    /// Returns an immutable slice of the string channel's bytes.
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr() as *const u8, self.len) }
+    }
+
+    /// Returns a mutable slice of the string channel's bytes.
     ///
-    /// # Arguments
-    /// A slice of bytes to be copied into the channel's buffer
-    /// If this slice is longer than the channel's buffer, only
-    /// Channel's size elements would be copied from it
-    pub fn write(&self, inp: &[u8]) {
-        let mut len = inp.len();
-        let size = self.len;
-        if size < len {
-            len = size;
-        }
+    /// # Safety
+    /// Caller must ensure no aliasing occurs with csound's internal access.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr() as *mut u8, self.len) }
+    }
+
+    /// Writes bytes to the string channel.
+    ///
+    /// If the input slice is longer than the channel buffer,
+    /// only `len()` bytes will be copied.
+    pub fn write(&self, bytes: &[u8]) {
+        let copy_len = bytes.len().min(self.len);
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
-            std::ptr::copy(inp.as_ptr(), self.ptr as *mut u8, len);
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), self.ptr.as_ptr() as *mut u8, copy_len);
         }
     }
 }
 
-impl<'a> AsRef<f64> for OutputChannel<'a, ControlChannel> {
-    fn as_ref(&self) -> &f64 {
-        unsafe { &*self.ptr }
+impl<'a> OutputChannel<'a, StrChannel> {
+    /// Returns an immutable slice of the string channel's bytes.
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr() as *const u8, self.len) }
+    }
+
+    /// Reads the string channel's bytes (alias for `as_slice`).
+    #[inline]
+    pub fn read(&self) -> &[u8] {
+        self.as_slice()
     }
 }
-
-impl<'a> AsRef<f64> for InputChannel<'a, ControlChannel> {
-    fn as_ref(&self) -> &f64 {
-        unsafe { &*self.ptr }
-    }
-}
-
-impl<'a> AsMut<f64> for InputChannel<'a, ControlChannel> {
-    fn as_mut(&mut self) -> &mut f64 {
-        unsafe { &mut *self.ptr }
-    }
-}
-
-// Internal macro used to generate AudioChannel and StrChannel implementations
-// for the AsRef trait.
-macro_rules! impl_asref_for_channel_ptr {
-    ($ct:ty, $t:ty) => {
-        impl<'a> AsRef<[$t]> for OutputChannel<'a, $ct> {
-            fn as_ref(&self) -> &[$t] {
-                unsafe { slice::from_raw_parts(self.ptr as *const $t, self.len) }
-            }
-        }
-    };
-}
-
-// Internal macro used to generate AudioChannel and StrChannel implementations
-// for the AsMut trait.
-macro_rules! impl_asmut_for_channel_ptr {
-    ($ct:ty, $t:ty) => {
-        impl<'a> AsMut<[$t]> for InputChannel<'a, $ct> {
-            fn as_mut(&mut self) -> &mut [$t] {
-                unsafe { slice::from_raw_parts_mut(self.ptr as *mut $t, self.len) }
-            }
-        }
-    };
-}
-
-impl_asref_for_channel_ptr!(AudioChannel, f64);
-impl_asref_for_channel_ptr!(StrChannel, u8);
-
-impl_asmut_for_channel_ptr!(AudioChannel, f64);
-impl_asmut_for_channel_ptr!(StrChannel, u8);
-
-// Deref implementations for OutputChannel - delegates to AsRef
-impl<'a> Deref for OutputChannel<'a, ControlChannel> {
-    type Target = f64;
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.ptr }
-    }
-}
-
-impl<'a> Deref for OutputChannel<'a, AudioChannel> {
-    type Target = [f64];
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { slice::from_raw_parts(self.ptr, self.len) }
-    }
-}
-
-impl<'a> Deref for OutputChannel<'a, StrChannel> {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
-    }
-}
-
-// Deref implementations for InputChannel - direct pointer access to avoid recursion
-impl<'a> Deref for InputChannel<'a, ControlChannel> {
-    type Target = f64;
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.ptr }
-    }
-}
-
-impl<'a> Deref for InputChannel<'a, AudioChannel> {
-    type Target = [f64];
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { slice::from_raw_parts(self.ptr, self.len) }
-    }
-}
-
-impl<'a> Deref for InputChannel<'a, StrChannel> {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
-    }
-}
-
-// Internal macro used to generate ControlChannel, AudioChannel and StrChannel implementations
-// for the DerefMut trait.
-macro_rules! impl_deref_mut_for_channel_ptr {
-    ($ct:ty, $t:ty) => {
-        impl<'a> DerefMut for InputChannel<'a, $ct> {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                self.as_mut()
-            }
-        }
-    };
-}
-
-impl_deref_mut_for_channel_ptr!(ControlChannel, f64);
-impl_deref_mut_for_channel_ptr!(AudioChannel, [f64]);
-impl_deref_mut_for_channel_ptr!(StrChannel, [u8]);

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -1071,17 +1069,17 @@ impl Csound {
         let bits;
 
         match T::c_type() {
-            ControlChannelType::CSOUND_AUDIO_CHANNEL => {
+            ControlChannelType::Audio => {
                 len = self.get_ksmps() as usize;
                 bits = (controlChannelType::CSOUND_AUDIO_CHANNEL
                     | controlChannelType::CSOUND_INPUT_CHANNEL) as c_int;
             }
-            ControlChannelType::CSOUND_CONTROL_CHANNEL => {
+            ControlChannelType::Control => {
                 len = 1;
                 bits = (controlChannelType::CSOUND_CONTROL_CHANNEL
                     | controlChannelType::CSOUND_INPUT_CHANNEL) as c_int;
             }
-            ControlChannelType::CSOUND_STRING_CHANNEL => {
+            ControlChannelType::String => {
                 len = self.get_channel_data_size(name) as usize;
                 bits = (controlChannelType::CSOUND_STRING_CHANNEL
                     | controlChannelType::CSOUND_INPUT_CHANNEL) as c_int;
@@ -1092,11 +1090,7 @@ impl Csound {
         unsafe {
             let result = Status::from(self.get_raw_channel_ptr(name, ptr, bits));
             match result {
-                Status::Success => Ok(InputChannel {
-                    ptr: *ptr,
-                    len,
-                    phantom: PhantomData,
-                }),
+                Status::Success => InputChannel::from_raw(*ptr, len).ok_or(Status::Error),
                 Status::Ok(channel) => Err(Status::Ok(channel)),
                 result => Err(result),
             }
@@ -1176,17 +1170,17 @@ impl Csound {
         let bits;
 
         match T::c_type() {
-            ControlChannelType::CSOUND_AUDIO_CHANNEL => {
+            ControlChannelType::Audio => {
                 len = self.get_ksmps() as usize;
                 bits = (controlChannelType::CSOUND_AUDIO_CHANNEL
                     | controlChannelType::CSOUND_OUTPUT_CHANNEL) as c_int;
             }
-            ControlChannelType::CSOUND_CONTROL_CHANNEL => {
+            ControlChannelType::Control => {
                 len = 1;
                 bits = (controlChannelType::CSOUND_CONTROL_CHANNEL
                     | controlChannelType::CSOUND_OUTPUT_CHANNEL) as c_int;
             }
-            ControlChannelType::CSOUND_STRING_CHANNEL => {
+            ControlChannelType::String => {
                 len = self.get_channel_data_size(name) as usize;
                 bits = (controlChannelType::CSOUND_STRING_CHANNEL
                     | controlChannelType::CSOUND_OUTPUT_CHANNEL) as c_int;
@@ -1197,11 +1191,7 @@ impl Csound {
         unsafe {
             let result = Status::from(self.get_raw_channel_ptr(name, ptr, bits));
             match result {
-                Status::Success => Ok(OutputChannel {
-                    ptr: *ptr,
-                    len,
-                    phantom: PhantomData,
-                }),
+                Status::Success => OutputChannel::from_raw(*ptr, len).ok_or(Status::Error),
                 Status::Ok(channel) => Err(Status::Ok(channel)),
                 result => Err(result),
             }
@@ -1611,7 +1601,7 @@ impl Csound {
     /// * `lang_code` can be for example any of [`Language`](enum.Language.html) variants.
     /// This affects all Csound instances running in the address
     /// space of the current process. The special language code
-    /// *Language::Default* can be used to disable translation of messages and
+    /// [`Language::Default`] can be used to disable translation of messages and
     /// free all memory allocated by a previous call to this function.
     /// set_language() loads all files for the selected language from the directory specified by the **CSSTRNGS** environment
     /// variable.

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,4 @@
 use bitflags::bitflags;
-use std::mem::transmute;
 
 #[derive(Debug, PartialEq)]
 /// An audio channel identifier
@@ -106,218 +105,339 @@ pub enum ChannelData {
 }
 
 bitflags! {
-    /// Defines the types of csound bus cahnnels
-    ///
-    /// and if the channel is an input or an output
-    #[derive(PartialEq)]
+    /// Defines the types of csound bus channels and their direction.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ControlChannelType: u32 {
-        /// Unknown channel - use it to request the channel type
-        const CSOUND_UNKNOWN_CHANNEL =     0;
-
-        /// Define a csound control channel
-        const CSOUND_CONTROL_CHANNEL =     1;
-        /// Define a audio channel (chanel content is and array with ksmps elements)
-        const CSOUND_AUDIO_CHANNEL  =      2;
-        /// String channel
-        const CSOUND_STRING_CHANNEL =      3;
-        /// Pvs channel
-        const CSOUND_PVS_CHANNEL =         4;
-        /// Generic channel
-        const CSOUND_VAR_CHANNEL =         5;
-
-        const CSOUND_CHANNEL_TYPE_MASK =   15;
-
-        const CSOUND_INPUT_CHANNEL =       16;
-
-        const CSOUND_OUTPUT_CHANNEL =      32;
+        /// Unknown channel - use to request the channel type.
+        const Unknown = 0;
+        /// Control channel (single MYFLT value).
+        const Control = 1;
+        /// Audio channel (array with ksmps elements).
+        const Audio = 2;
+        /// String channel.
+        const String = 3;
+        /// PVS channel.
+        const Pvs = 4;
+        /// Generic/variable channel.
+        const Var = 5;
+        /// Mask to extract channel type.
+        const TypeMask = 15;
+        /// Input channel flag.
+        const Input = 16;
+        /// Output channel flag.
+        const Output = 32;
     }
 }
 
 bitflags! {
-    /// Defines the types of csound bus cahnnels
-    ///
-    /// and if the channel is an input or an output
+    /// Keyboard callback types.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct KeyCallbackType: u8 {
-        /// Unknown channel - use it to request the channel type
-        const CSOUND_CALLBACK_KBD_EVENT = 1;
-        const CSOUND_CALLBACK_KBD_TEXT =  2;
+        /// Keyboard event callback.
+        const Event = 1;
+        /// Keyboard text callback.
+        const Text = 2;
     }
 }
 
-/// The languages supported by csound
-#[derive(Debug, Clone, PartialEq)]
+/// The languages supported by csound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
 pub enum Language {
-    CSLANGUAGE_DEFAULT = 0,
-    CSLANGUAGE_AFRIKAANS,
-    CSLANGUAGE_ALBANIAN,
-    CSLANGUAGE_ARABIC,
-    CSLANGUAGE_ARMENIAN,
-    CSLANGUAGE_ASSAMESE,
-    CSLANGUAGE_AZERI,
-    CSLANGUAGE_BASQUE,
-    CSLANGUAGE_BELARUSIAN,
-    CSLANGUAGE_BENGALI,
-    CSLANGUAGE_BULGARIAN,
-    CSLANGUAGE_CATALAN,
-    CSLANGUAGE_CHINESE,
-    CSLANGUAGE_CROATIAN,
-    CSLANGUAGE_CZECH,
-    CSLANGUAGE_DANISH,
-    CSLANGUAGE_DUTCH,
-    CSLANGUAGE_ENGLISH_UK,
-    CSLANGUAGE_ENGLISH_US,
-    CSLANGUAGE_ESTONIAN,
-    CSLANGUAGE_FAEROESE,
-    CSLANGUAGE_FARSI,
-    CSLANGUAGE_FINNISH,
-    CSLANGUAGE_FRENCH,
-    CSLANGUAGE_GEORGIAN,
-    CSLANGUAGE_GERMAN,
-    CSLANGUAGE_GREEK,
-    CSLANGUAGE_GUJARATI,
-    CSLANGUAGE_HEBREW,
-    CSLANGUAGE_HINDI,
-    CSLANGUAGE_HUNGARIAN,
-    CSLANGUAGE_ICELANDIC,
-    CSLANGUAGE_INDONESIAN,
-    CSLANGUAGE_ITALIAN,
-    CSLANGUAGE_JAPANESE,
-    CSLANGUAGE_KANNADA,
-    CSLANGUAGE_KASHMIRI,
-    CSLANGUAGE_KONKANI,
-    CSLANGUAGE_KOREAN,
-    CSLANGUAGE_LATVIAN,
-    CSLANGUAGE_LITHUANIAN,
-    CSLANGUAGE_MACEDONIAN,
-    CSLANGUAGE_MALAY,
-    CSLANGUAGE_MALAYALAM,
-    CSLANGUAGE_MANIPURI,
-    CSLANGUAGE_MARATHI,
-    CSLANGUAGE_NEPALI,
-    CSLANGUAGE_NORWEGIAN,
-    CSLANGUAGE_ORIYA,
-    CSLANGUAGE_POLISH,
-    CSLANGUAGE_PORTUGUESE,
-    CSLANGUAGE_PUNJABI,
-    CSLANGUAGE_ROMANIAN,
-    CSLANGUAGE_RUSSIAN,
-    CSLANGUAGE_SANSKRIT,
-    CSLANGUAGE_SERBIAN,
-    CSLANGUAGE_SINDHI,
-    CSLANGUAGE_SLOVAK,
-    CSLANGUAGE_SLOVENIAN,
-    CSLANGUAGE_SPANISH,
-    CSLANGUAGE_SWAHILI,
-    CSLANGUAGE_SWEDISH,
-    CSLANGUAGE_TAMIL,
-    CSLANGUAGE_TATAR,
-    CSLANGUAGE_TELUGU,
-    CSLANGUAGE_THAI,
-    CSLANGUAGE_TURKISH,
-    CSLANGUAGE_UKRAINIAN,
-    CSLANGUAGE_URDU,
-    CSLANGUAGE_UZBEK,
-    CSLANGUAGE_VIETNAMESE,
-    CSLANGUAGE_COLUMBIAN,
+    Default = 0,
+    Afrikaans = 1,
+    Albanian = 2,
+    Arabic = 3,
+    Armenian = 4,
+    Assamese = 5,
+    Azeri = 6,
+    Basque = 7,
+    Belarusian = 8,
+    Bengali = 9,
+    Bulgarian = 10,
+    Catalan = 11,
+    Chinese = 12,
+    Croatian = 13,
+    Czech = 14,
+    Danish = 15,
+    Dutch = 16,
+    EnglishUk = 17,
+    EnglishUs = 18,
+    Estonian = 19,
+    Faeroese = 20,
+    Farsi = 21,
+    Finnish = 22,
+    French = 23,
+    Georgian = 24,
+    German = 25,
+    Greek = 26,
+    Gujarati = 27,
+    Hebrew = 28,
+    Hindi = 29,
+    Hungarian = 30,
+    Icelandic = 31,
+    Indonesian = 32,
+    Italian = 33,
+    Japanese = 34,
+    Kannada = 35,
+    Kashmiri = 36,
+    Konkani = 37,
+    Korean = 38,
+    Latvian = 39,
+    Lithuanian = 40,
+    Macedonian = 41,
+    Malay = 42,
+    Malayalam = 43,
+    Manipuri = 44,
+    Marathi = 45,
+    Nepali = 46,
+    Norwegian = 47,
+    Oriya = 48,
+    Polish = 49,
+    Portuguese = 50,
+    Punjabi = 51,
+    Romanian = 52,
+    Russian = 53,
+    Sanskrit = 54,
+    Serbian = 55,
+    Sindhi = 56,
+    Slovak = 57,
+    Slovenian = 58,
+    Spanish = 59,
+    Swahili = 60,
+    Swedish = 61,
+    Tamil = 62,
+    Tatar = 63,
+    Telugu = 64,
+    Thai = 65,
+    Turkish = 66,
+    Ukrainian = 67,
+    Urdu = 68,
+    Uzbek = 69,
+    Vietnamese = 70,
+    Columbian = 71,
 }
 
-/// Describes the differents file types which are supported are by csound
+/// Describes the different file types supported by csound.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum FileTypes {
-    /* This should only be used internally by the original FileOpen()
-    API call or for temp files written with <CsFileB> */
-    CSFTYPE_UNKNOWN = 0,
-    CSFTYPE_UNIFIED_CSD = 1, /* Unified Csound document */
-    CSFTYPE_ORCHESTRA,       /* the primary orc file (may be temporary) */
-    CSFTYPE_SCORE,           /* the primary sco file (may be temporary)
-                             or any additional score opened by Cscore */
-    CSFTYPE_ORC_INCLUDE,   /* a file #included by the orchestra */
-    CSFTYPE_SCO_INCLUDE,   /* a file #included by the score */
-    CSFTYPE_SCORE_OUT,     /* used for score.srt, score.xtr, cscore.out */
-    CSFTYPE_SCOT,          /* Scot score input format */
-    CSFTYPE_OPTIONS,       /* for .csoundrc and -@ flag */
-    CSFTYPE_EXTRACT_PARMS, /* extraction file specified by -x */
+    /// Unknown file type (internal use or temp files).
+    Unknown,
+    /// Unified Csound document (.csd).
+    UnifiedCsd,
+    /// Primary orchestra file (may be temporary).
+    Orchestra,
+    /// Primary score file or additional score opened by Cscore.
+    Score,
+    /// File #included by the orchestra.
+    OrcInclude,
+    /// File #included by the score.
+    ScoInclude,
+    /// Output score files (score.srt, score.xtr, cscore.out).
+    ScoreOut,
+    /// Scot score input format.
+    Scot,
+    /// Options file (.csoundrc or -@ flag).
+    Options,
+    /// Extraction file specified by -x.
+    ExtractParms,
 
-    /* audio file types that Csound can write (10-19) or read */
-    CSFTYPE_RAW_AUDIO,
-    CSFTYPE_IRCAM,
-    CSFTYPE_AIFF,
-    CSFTYPE_AIFC,
-    CSFTYPE_WAVE,
-    CSFTYPE_AU,
-    CSFTYPE_SD2,
-    CSFTYPE_W64,
-    CSFTYPE_WAVEX,
-    CSFTYPE_FLAC,
-    CSFTYPE_CAF,
-    CSFTYPE_WVE,
-    CSFTYPE_OGG,
-    CSFTYPE_MPC2K,
-    CSFTYPE_RF64,
-    CSFTYPE_AVR,
-    CSFTYPE_HTK,
-    CSFTYPE_MAT4,
-    CSFTYPE_MAT5,
-    CSFTYPE_NIST,
-    CSFTYPE_PAF,
-    CSFTYPE_PVF,
-    CSFTYPE_SDS,
-    CSFTYPE_SVX,
-    CSFTYPE_VOC,
-    CSFTYPE_XI,
-    CSFTYPE_UNKNOWN_AUDIO, /* used when opening audio file for reading
-                           or temp file written with <CsSampleB> */
+    // Audio file types (10-36)
+    /// Raw audio format.
+    RawAudio,
+    /// IRCAM format.
+    Ircam,
+    /// AIFF format.
+    Aiff,
+    /// AIFC format.
+    Aifc,
+    /// WAV format.
+    Wave,
+    /// AU format.
+    Au,
+    /// SD2 format.
+    Sd2,
+    /// W64 format.
+    W64,
+    /// WAVEX format.
+    Wavex,
+    /// FLAC format.
+    Flac,
+    /// CAF format.
+    Caf,
+    /// WVE format.
+    Wve,
+    /// OGG format.
+    Ogg,
+    /// MPC2K format.
+    Mpc2k,
+    /// RF64 format.
+    Rf64,
+    /// AVR format.
+    Avr,
+    /// HTK format.
+    Htk,
+    /// MAT4 format.
+    Mat4,
+    /// MAT5 format.
+    Mat5,
+    /// NIST format.
+    Nist,
+    /// PAF format.
+    Paf,
+    /// PVF format.
+    Pvf,
+    /// SDS format.
+    Sds,
+    /// SVX format.
+    Svx,
+    /// VOC format.
+    Voc,
+    /// XI format.
+    Xi,
+    /// Unknown audio format (reading audio or <CsSampleB> temp).
+    UnknownAudio,
 
-    /* miscellaneous music formats */
-    CSFTYPE_SOUNDFONT,
-    CSFTYPE_STD_MIDI,   /* Standard MIDI file */
-    CSFTYPE_MIDI_SYSEX, /* Raw MIDI codes, eg. SysEx dump */
+    // Miscellaneous music formats (37-39)
+    /// SoundFont format.
+    Soundfont,
+    /// Standard MIDI file.
+    StdMidi,
+    /// Raw MIDI codes (e.g. SysEx dump).
+    MidiSysex,
 
-    /* analysis formats */
-    CSFTYPE_HETRO,
-    CSFTYPE_HETROT,
-    CSFTYPE_PVC,   /* original PVOC format */
-    CSFTYPE_PVCEX, /* PVOC-EX format */
-    CSFTYPE_CVANAL,
-    CSFTYPE_LPC,
-    CSFTYPE_ATS,
-    CSFTYPE_LORIS,
-    CSFTYPE_SDIF,
-    CSFTYPE_HRTF,
+    // Analysis formats (40-51)
+    /// Hetro analysis format.
+    Hetro,
+    /// Hetrot analysis format.
+    Hetrot,
+    /// Original PVOC format.
+    Pvc,
+    /// PVOC-EX format.
+    Pvcex,
+    /// CVANAL format.
+    Cvanal,
+    /// LPC format.
+    Lpc,
+    /// ATS format.
+    Ats,
+    /// Loris format.
+    Loris,
+    /// SDIF format.
+    Sdif,
+    /// HRTF format.
+    Hrtf,
 
-    /* Types for plugins and the files they read/write */
-    CSFTYPE_UNUSED,
-    CSFTYPE_LADSPA_PLUGIN,
-    CSFTYPE_SNAPSHOT,
+    // Plugin types (52-54)
+    /// Unused type.
+    Unused,
+    /// LADSPA plugin.
+    LadspaPlugin,
+    /// Snapshot file.
+    Snapshot,
 
-    /* Special formats for Csound ftables or scanned synthesis
-    matrices with header info */
-    CSFTYPE_FTABLES_TEXT,   /* for ftsave and ftload  */
-    CSFTYPE_FTABLES_BINARY, /* for ftsave and ftload  */
-    CSFTYPE_XSCANU_MATRIX,  /* for xscanu opcode  */
+    // Ftable and matrix formats (55-57)
+    /// Text format for ftsave/ftload.
+    FtablesText,
+    /// Binary format for ftsave/ftload.
+    FtablesBinary,
+    /// Matrix file for xscanu opcode.
+    XscanuMatrix,
 
-    /* These are for raw lists of numbers without header info */
-    CSFTYPE_FLOATS_TEXT,    /* used by GEN23, GEN28, dumpk, readk */
-    CSFTYPE_FLOATS_BINARY,  /* used by dumpk, readk, etc. */
-    CSFTYPE_INTEGER_TEXT,   /* used by dumpk, readk, etc. */
-    CSFTYPE_INTEGER_BINARY, /* used by dumpk, readk, etc. */
+    // Raw number lists (58-61)
+    /// Text floats (GEN23, GEN28, dumpk, readk).
+    FloatsText,
+    /// Binary floats (dumpk, readk, etc.).
+    FloatsBinary,
+    /// Text integers (dumpk, readk, etc.).
+    IntegerText,
+    /// Binary integers (dumpk, readk, etc.).
+    IntegerBinary,
 
-    /* image file formats */
-    CSFTYPE_IMAGE_PNG,
+    // Image formats (62)
+    /// PNG image format.
+    ImagePng,
 
-    /* For files that don't match any of the above */
-    CSFTYPE_POSTSCRIPT,  /* EPS format used by graphs */
-    CSFTYPE_SCRIPT_TEXT, /* executable script files (eg. Python) */
-    CSFTYPE_OTHER_TEXT,
-    CSFTYPE_OTHER_BINARY,
+    // Other formats (63-66)
+    /// PostScript/EPS format (graphs).
+    Postscript,
+    /// Executable script files (e.g. Python).
+    ScriptText,
+    /// Other text format.
+    OtherText,
+    /// Other binary format.
+    OtherBinary,
 }
 
 impl From<u8> for FileTypes {
-    fn from(item: u8) -> Self {
-        if item > 63 {
-            FileTypes::CSFTYPE_UNKNOWN
-        } else {
-            unsafe { transmute(item) }
+    fn from(value: u8) -> Self {
+        match value {
+            0 => FileTypes::Unknown,
+            1 => FileTypes::UnifiedCsd,
+            2 => FileTypes::Orchestra,
+            3 => FileTypes::Score,
+            4 => FileTypes::OrcInclude,
+            5 => FileTypes::ScoInclude,
+            6 => FileTypes::ScoreOut,
+            7 => FileTypes::Scot,
+            8 => FileTypes::Options,
+            9 => FileTypes::ExtractParms,
+            10 => FileTypes::RawAudio,
+            11 => FileTypes::Ircam,
+            12 => FileTypes::Aiff,
+            13 => FileTypes::Aifc,
+            14 => FileTypes::Wave,
+            15 => FileTypes::Au,
+            16 => FileTypes::Sd2,
+            17 => FileTypes::W64,
+            18 => FileTypes::Wavex,
+            19 => FileTypes::Flac,
+            20 => FileTypes::Caf,
+            21 => FileTypes::Wve,
+            22 => FileTypes::Ogg,
+            23 => FileTypes::Mpc2k,
+            24 => FileTypes::Rf64,
+            25 => FileTypes::Avr,
+            26 => FileTypes::Htk,
+            27 => FileTypes::Mat4,
+            28 => FileTypes::Mat5,
+            29 => FileTypes::Nist,
+            30 => FileTypes::Paf,
+            31 => FileTypes::Pvf,
+            32 => FileTypes::Sds,
+            33 => FileTypes::Svx,
+            34 => FileTypes::Voc,
+            35 => FileTypes::Xi,
+            36 => FileTypes::UnknownAudio,
+            37 => FileTypes::Soundfont,
+            38 => FileTypes::StdMidi,
+            39 => FileTypes::MidiSysex,
+            40 => FileTypes::Hetro,
+            41 => FileTypes::Hetrot,
+            42 => FileTypes::Pvc,
+            43 => FileTypes::Pvcex,
+            44 => FileTypes::Cvanal,
+            45 => FileTypes::Lpc,
+            46 => FileTypes::Ats,
+            47 => FileTypes::Loris,
+            48 => FileTypes::Sdif,
+            49 => FileTypes::Hrtf,
+            50 => FileTypes::Unused,
+            51 => FileTypes::LadspaPlugin,
+            52 => FileTypes::Snapshot,
+            53 => FileTypes::FtablesText,
+            54 => FileTypes::FtablesBinary,
+            55 => FileTypes::XscanuMatrix,
+            56 => FileTypes::FloatsText,
+            57 => FileTypes::FloatsBinary,
+            58 => FileTypes::IntegerText,
+            59 => FileTypes::IntegerBinary,
+            60 => FileTypes::ImagePng,
+            61 => FileTypes::Postscript,
+            62 => FileTypes::ScriptText,
+            63 => FileTypes::OtherText,
+            64 => FileTypes::OtherBinary,
+            _ => FileTypes::Unknown,
         }
     }
 }


### PR DESCRIPTION
BREAKING CHANGES:
- ControlChannelType flags renamed: CSOUND_CONTROL_CHANNEL -> Control, etc.
- KeyCallbackType flags renamed: CSOUND_CALLBACK_KBD_EVENT -> Event, etc.
- FileTypes variants renamed to PascalCase: CSFTYPE_UNKNOWN -> Unknown, etc.
- Language variants renamed to PascalCase: CSLANGUAGE_DEFAULT -> Default, etc.
- Channel API: removed Deref/DerefMut, use explicit get()/set()/write()/read()

Enum Renames:
- ControlChannelType: Unknown, Control, Audio, String, Pvs, Var, TypeMask, Input, Output
- KeyCallbackType: Event, Text
- FileTypes: 65 variants renamed (Unknown, UnifiedCsd, Orchestra, Wave, etc.)
- Language: 72 variants renamed (Default, EnglishUk, EnglishUs, French, etc.)

Channel API Improvements:
- Replace raw *mut f64 pointers with NonNull<f64> for null safety
- Remove Deref/DerefMut implementations (prevents aliasing issues with FFI)
- Add explicit methods: get(), set(), write(), read(), as_slice(), as_mut_slice()
- Add len() and is_empty() methods to InputChannel/OutputChannel
- Make struct fields private with pub(crate) from_raw() constructors
- Add Send implementations with safety documentation

Safety Improvements:
- Remove unsafe transmute in FileTypes::from() - use safe match instead
- Add #[repr(u32)] to Language enum for FFI compatibility

Examples Updated:
- example7-10: Rename random_line -> RandomLine, use impl methods
- example10: Use channel.set(value) instead of *channel = value
- Remove #![allow(non_snake_case)] attributes