### PR TITLE
fix(width): align API with MYFLT and fix RT callback length handling

### DIFF
--- a/csound-sys/build.rs
+++ b/csound-sys/build.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use bindgen::{EnumVariation, builder};
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(csound_sys_use_double)");
     if !link() {
         println!("cargo:warning=libcsound64 library not found in your system");
         println!(
@@ -31,6 +32,16 @@ fn generate_bindings() {
     println!("cargo:rerun-if-changed=csound/include/csound_type_system.h");
 
     // mind there could be platform-dependent flags, so check compilation instructions per platform
+    println!("cargo:rerun-if-env-changed=CSOUND_USE_DOUBLE");
+    let use_double = match env::var("CSOUND_USE_DOUBLE") {
+        Ok(val) => val != "0",
+        Err(_) => true,
+    };
+
+    if use_double {
+        println!("cargo:rustc-cfg=csound_sys_use_double");
+    }
+
     let bindings = builder()
         .header("csound/include/csound.h")
         .header("csound/include/csound_circular_buffer.h")
@@ -55,10 +66,15 @@ fn generate_bindings() {
         .blocklist_function("c[^s].*")
         .blocklist_function("cs[^o].*")
         // default flags defined in CMakeLists (only those, which applicable)
-        .clang_arg("-DUSE_DOUBLE")
-        .clang_arg("-DUSE_LRINT")
-        .generate()
-        .expect("Unable generate bindings");
+        .clang_arg("-DUSE_LRINT");
+
+    let bindings = if use_double {
+        bindings.clang_arg("-DUSE_DOUBLE")
+    } else {
+        bindings
+    }
+    .generate()
+    .expect("Unable generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings

--- a/csound-sys/src/lib.rs
+++ b/csound-sys/src/lib.rs
@@ -13,6 +13,11 @@ pub use selected_bindings::*;
 /// The current module publicly re-exports bindgen generated structs, functions,
 /// and constants, for their direct usage.
 mod selected_bindings {
+    /// Csound sample type (MYFLT) as defined by the Csound build.
+    #[cfg(csound_sys_use_double)]
+    pub type MYFLT = libc::c_double;
+    #[cfg(not(csound_sys_use_double))]
+    pub type MYFLT = libc::c_float;
 
     /// Rust FFI bindings, automatically generated with bindgen.
     // [clippy & bindgen](https://github.com/rust-lang/rust-bindgen/issues/1470)

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use bitflags::bitflags;
 
+use crate::Myflt;
 use crate::enums::{ChannelData, FileTypes, MessageType, Status};
 use crate::rtaudio::{CsAudioDevice, RtAudioParams};
 
@@ -93,8 +94,8 @@ pub struct FileInfo {
 type MessageCallback<'a> = Option<Box<dyn FnMut(MessageType, &str) + 'a>>;
 type DevlistCallback<'a> = Option<Box<dyn FnMut(CsAudioDevice) + 'a>>;
 type RtAudioOpenCallback<'a> = Option<Box<dyn FnMut(&RtAudioParams) -> Status + 'a>>;
-type RtPlayCallback<'a> = Option<Box<dyn FnMut(&[f64]) + 'a>>;
-type RtRecCallback<'a> = Option<Box<dyn FnMut(&mut [f64]) -> usize + 'a>>;
+type RtPlayCallback<'a> = Option<Box<dyn FnMut(&[Myflt]) + 'a>>;
+type RtRecCallback<'a> = Option<Box<dyn FnMut(&mut [Myflt]) -> usize + 'a>>;
 type InputChannelCallback<'a> = Option<Box<dyn FnMut(&str) -> ChannelData + 'a>>;
 type OutputChannelCallback<'a> = Option<Box<dyn FnMut(&str, ChannelData) + 'a>>;
 type FileOpenCallback<'a> = Option<Box<dyn FnMut(&FileInfo) + 'a>>;
@@ -174,7 +175,7 @@ impl<'a> Callbacks<'a> {
 
     pub(crate) unsafe fn set_rt_play_cb<F>(&'a mut self, csound: *mut raw::CSOUND, cb: F)
     where
-        F: FnMut(&[f64]) + 'a,
+        F: FnMut(&[Myflt]) + 'a,
     {
         unsafe {
             self.rt_play_cb = Some(Box::new(cb));
@@ -184,7 +185,7 @@ impl<'a> Callbacks<'a> {
 
     pub(crate) unsafe fn set_rt_rec_cb<F>(&'a mut self, csound: *mut raw::CSOUND, cb: F)
     where
-        F: FnMut(&mut [f64]) -> usize + 'a,
+        F: FnMut(&mut [Myflt]) -> usize + 'a,
     {
         unsafe {
             self.rt_rec_cb = Some(Box::new(cb));
@@ -588,14 +589,20 @@ pub mod Trampoline {
         );
     }
 
-    pub extern "C" fn rtplayCallback(csound: *mut raw::CSOUND, outBuf: *const f64, nbytes: c_int) {
+    pub extern "C" fn rtplayCallback(
+        csound: *mut raw::CSOUND,
+        outBuf: *const Myflt,
+        nbytes: c_int,
+    ) {
         let handler = unsafe { get_handler(csound) };
         catch_callback_void(
             &handler.panic_state,
             PanickedCallbacks::RT_PLAY,
             "rtplayCallback",
             || unsafe {
-                let out = slice::from_raw_parts(outBuf, nbytes as usize);
+                let bytes = if nbytes > 0 { nbytes as usize } else { 0 };
+                let samples = bytes / std::mem::size_of::<Myflt>();
+                let out = slice::from_raw_parts(outBuf, samples);
                 if let Some(fun) = handler.callbacks.rt_play_cb.as_mut() {
                     fun(out);
                 }
@@ -605,7 +612,7 @@ pub mod Trampoline {
 
     pub extern "C" fn rtrecordCallback(
         csound: *mut raw::CSOUND,
-        outBuf: *mut f64,
+        outBuf: *mut Myflt,
         nbytes: c_int,
     ) -> c_int {
         let handler = unsafe { get_handler(csound) };
@@ -615,9 +622,14 @@ pub mod Trampoline {
             "rtrecordCallback",
             -1,
             || unsafe {
-                let buff = slice::from_raw_parts_mut(outBuf, nbytes as usize);
+                let bytes = if nbytes > 0 { nbytes as usize } else { 0 };
+                let samples = bytes / std::mem::size_of::<Myflt>();
+                let buff = slice::from_raw_parts_mut(outBuf, samples);
                 if let Some(fun) = handler.callbacks.rt_rec_cb.as_mut() {
-                    return fun(buff) as c_int;
+                    let written = fun(buff);
+                    let bytes = written.saturating_mul(std::mem::size_of::<Myflt>());
+                    let bytes = bytes.min(c_int::MAX as usize);
+                    return bytes as c_int;
                 }
                 -1
             },
@@ -707,7 +719,7 @@ pub mod Trampoline {
 
                 match result {
                     ChannelData::Control(data) => {
-                        *(channelValuePtr as *mut f64) = data;
+                        *(channelValuePtr as *mut Myflt) = data;
                     }
                     ChannelData::String(s) => {
                         let len = s.len();
@@ -754,7 +766,7 @@ pub mod Trampoline {
 
                 match channel_type as u32 {
                     controlChannelType::CSOUND_CONTROL_CHANNEL => {
-                        let value = *(channelValuePtr as *mut f64);
+                        let value = *(channelValuePtr as *mut Myflt);
                         let data = ChannelData::Control(value);
                         fun(name, data);
                     }
@@ -917,6 +929,43 @@ pub mod Trampoline {
                 0
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Trampoline;
+    use crate::{Csound, Myflt};
+    use libc::c_int;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn rtplay_callback_nbytes_is_bytes_not_elements() {
+        let cs = Csound::new().expect("Failed to create Csound instance");
+
+        let seen_len = Arc::new(AtomicUsize::new(0));
+        let seen_len_clone = Arc::clone(&seen_len);
+
+        cs.rt_audio_play_callback(move |buffer: &[Myflt]| {
+            seen_len_clone.store(buffer.len(), Ordering::SeqCst);
+        });
+
+        // nbytes is defined by Csound as a byte count. We deliberately allocate a larger
+        // buffer (nbytes elements) to avoid UB with the current buggy implementation.
+        let nbytes: usize = 64;
+        let buffer = vec![0.0 as Myflt; nbytes];
+
+        let csound_ptr = cs.engine.csound.as_ptr();
+        Trampoline::rtplayCallback(csound_ptr, buffer.as_ptr(), nbytes as c_int);
+
+        let expected = nbytes / std::mem::size_of::<Myflt>();
+        let actual = seen_len.load(Ordering::SeqCst);
+        assert_eq!(
+            actual, expected,
+            "rtplayCallback should pass a slice length derived from bytes (expected {}), got {}",
+            expected, actual
+        );
     }
 }
 

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::slice;
 
+use crate::Myflt;
 use crate::enums::{AudioChannel, ControlChannel, ControlChannelType, StrChannel};
 
 /// Indicates the channel behavior.
@@ -57,11 +58,11 @@ pub struct ChannelHints {
     /// The channel behavior hint (e.g., linear, exponential scaling).
     pub behav: ChannelBehavior,
     /// Default value for the channel.
-    pub dflt: f64,
+    pub dflt: Myflt,
     /// Minimum value for the channel.
-    pub min: f64,
+    pub min: Myflt,
     /// Maximum value for the channel.
-    pub max: f64,
+    pub max: Myflt,
     /// Suggested x position for GUI display.
     pub x: i32,
     /// Suggested y position for GUI display.
@@ -87,9 +88,9 @@ impl Default for ChannelHints {
     fn default() -> ChannelHints {
         ChannelHints {
             behav: ChannelBehavior::NoHints,
-            dflt: 0f64,
-            min: 0f64,
-            max: 0f64,
+            dflt: 0.0 as Myflt,
+            min: 0.0 as Myflt,
+            max: 0.0 as Myflt,
             x: 0i32,
             y: 0i32,
             width: 0i32,
@@ -158,7 +159,7 @@ impl PvsDataExt {
 /// rather than relying on implicit dereferencing.
 #[derive(Debug)]
 pub struct InputChannel<'a, T> {
-    ptr: NonNull<f64>,
+    ptr: NonNull<Myflt>,
     len: usize,
     phantom: PhantomData<&'a mut T>,
 }
@@ -170,7 +171,7 @@ pub struct InputChannel<'a, T> {
 /// rather than relying on implicit dereferencing.
 #[derive(Debug)]
 pub struct OutputChannel<'a, T> {
-    ptr: NonNull<f64>,
+    ptr: NonNull<Myflt>,
     len: usize,
     phantom: PhantomData<&'a T>,
 }
@@ -185,7 +186,7 @@ impl<'a, T> InputChannel<'a, T> {
     ///
     /// # Safety
     /// The pointer must be valid and point to memory owned by csound.
-    pub(crate) unsafe fn from_raw(ptr: *mut f64, len: usize) -> Option<Self> {
+    pub(crate) unsafe fn from_raw(ptr: *mut Myflt, len: usize) -> Option<Self> {
         NonNull::new(ptr).map(|ptr| InputChannel {
             ptr,
             len,
@@ -211,7 +212,7 @@ impl<'a, T> OutputChannel<'a, T> {
     ///
     /// # Safety
     /// The pointer must be valid and point to memory owned by csound.
-    pub(crate) unsafe fn from_raw(ptr: *mut f64, len: usize) -> Option<Self> {
+    pub(crate) unsafe fn from_raw(ptr: *mut Myflt, len: usize) -> Option<Self> {
         NonNull::new(ptr).map(|ptr| OutputChannel {
             ptr,
             len,
@@ -261,14 +262,14 @@ impl IsChannel for StrChannel {
 impl<'a> InputChannel<'a, ControlChannel> {
     /// Gets the current value of the control channel.
     #[inline]
-    pub fn get(&self) -> f64 {
+    pub fn get(&self) -> Myflt {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { *self.ptr.as_ptr() }
     }
 
     /// Sets the value of the control channel.
     #[inline]
-    pub fn set(&self, value: f64) {
+    pub fn set(&self, value: Myflt) {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
             *self.ptr.as_ptr() = value;
@@ -277,7 +278,7 @@ impl<'a> InputChannel<'a, ControlChannel> {
 
     /// Writes a value to the control channel (alias for `set`).
     #[inline]
-    pub fn write(&self, value: f64) {
+    pub fn write(&self, value: Myflt) {
         self.set(value);
     }
 }
@@ -285,14 +286,14 @@ impl<'a> InputChannel<'a, ControlChannel> {
 impl<'a> OutputChannel<'a, ControlChannel> {
     /// Gets the current value of the control channel.
     #[inline]
-    pub fn get(&self) -> f64 {
+    pub fn get(&self) -> Myflt {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { *self.ptr.as_ptr() }
     }
 
     /// Reads the value from the control channel (alias for `get`).
     #[inline]
-    pub fn read(&self) -> f64 {
+    pub fn read(&self) -> Myflt {
         self.get()
     }
 }
@@ -304,7 +305,7 @@ impl<'a> OutputChannel<'a, ControlChannel> {
 impl<'a> InputChannel<'a, AudioChannel> {
     /// Returns an immutable slice of the audio channel's samples.
     #[inline]
-    pub fn as_slice(&self) -> &[f64] {
+    pub fn as_slice(&self) -> &[Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
     }
@@ -314,7 +315,7 @@ impl<'a> InputChannel<'a, AudioChannel> {
     /// # Safety
     /// Caller must ensure no aliasing occurs with csound's internal access.
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [f64] {
+    pub fn as_mut_slice(&mut self) -> &mut [Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
@@ -323,7 +324,7 @@ impl<'a> InputChannel<'a, AudioChannel> {
     ///
     /// If the input slice is longer than the channel buffer,
     /// only `len()` samples will be copied.
-    pub fn write(&self, samples: &[f64]) {
+    pub fn write(&self, samples: &[Myflt]) {
         let copy_len = samples.len().min(self.len);
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
@@ -335,14 +336,14 @@ impl<'a> InputChannel<'a, AudioChannel> {
 impl<'a> OutputChannel<'a, AudioChannel> {
     /// Returns an immutable slice of the audio channel's samples.
     #[inline]
-    pub fn as_slice(&self) -> &[f64] {
+    pub fn as_slice(&self) -> &[Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
     }
 
     /// Reads the audio samples from the channel (alias for `as_slice`).
     #[inline]
-    pub fn read(&self) -> &[f64] {
+    pub fn read(&self) -> &[Myflt] {
         self.as_slice()
     }
 }

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -14,14 +14,14 @@ use crate::enums::{
 use crate::error::{Error, Result};
 use crate::rtaudio::{CsAudioDevice, CsMidiDevice, RtAudioParams};
 use crate::table::TableId;
-use crate::{Table, callbacks::*};
+use crate::{Myflt, Table, callbacks::*};
 
 use csound_sys::{CSOUND_STATUS, RTCLOCK, controlChannelType};
 
 use std::ffi::{CStr, CString};
 use std::str;
 
-use libc::{c_char, c_double, c_int, c_long, c_void};
+use libc::{c_char, c_int, c_long, c_void};
 
 /// Struct with information about a csound opcode.
 ///
@@ -115,6 +115,13 @@ impl Csound {
                 csound_sys::csoundInitialize(flags);
             }
         });
+
+        // Ensure MYFLT size matches the linked Csound library.
+        let expected = std::mem::size_of::<crate::Myflt>();
+        let actual = unsafe { csound_sys::csoundGetSizeOfMYFLT() as usize };
+        if expected != actual {
+            return Err(Error::MyfltMismatch { expected, actual });
+        }
 
         // Create the callback handler
         let callback_handler = Box::new(CallbackHandler {
@@ -409,7 +416,7 @@ impl Csound {
     ///   'return' opcode in global space.
     ///       code = "i1 = 2 + 2 \n return i1 \n"
     ///       retval = csound.eval_code(code)
-    pub fn eval_code<T>(&self, code: T) -> Result<f64>
+    pub fn eval_code<T>(&self, code: T) -> Result<Myflt>
     where
         T: AsRef<str>,
     {
@@ -428,7 +435,7 @@ impl Csound {
 
     // TODO Implement csoundCompileTree functions
 
-    /// Senses input events, and performs one control sample worth ```ksmps * number of channels * size_off::<f64> bytes``` of audio output.
+    /// Senses input events, and performs one control sample worth ```ksmps * number of channels * size_of::<Myflt> bytes``` of audio output.
     ///
     /// Note that some csd file, text or score have to be compiled first and then [`Csound::start`](struct.Csound.html#method.start).
     /// Enables external software to control the execution of Csound, and to synchronize
@@ -519,14 +526,14 @@ impl Csound {
 
     /// # Returns
     /// The number of audio sample frames per second.
-    pub fn get_sample_rate(&self) -> f64 {
-        unsafe { csound_sys::csoundGetSr(self.csound_ptr()) as f64 }
+    pub fn get_sample_rate(&self) -> Myflt {
+        unsafe { csound_sys::csoundGetSr(self.csound_ptr()) as Myflt }
     }
 
     /// # Returns
     /// The number of control samples per second.
-    pub fn get_control_rate(&self) -> f64 {
-        unsafe { csound_sys::csoundGetKr(self.csound_ptr()) as f64 }
+    pub fn get_control_rate(&self) -> Myflt {
+        unsafe { csound_sys::csoundGetKr(self.csound_ptr()) as Myflt }
     }
 
     /// # Returns
@@ -544,14 +551,14 @@ impl Csound {
 
     /// # Returns
     /// The 0dBFS level of the spin/spout buffers.
-    pub fn get_0d_bfs(&self) -> f64 {
-        unsafe { csound_sys::csoundGet0dBFS(self.csound_ptr()) as f64 }
+    pub fn get_0d_bfs(&self) -> Myflt {
+        unsafe { csound_sys::csoundGet0dBFS(self.csound_ptr()) as Myflt }
     }
 
     /// # Returns
     /// The A4 frequency reference
-    pub fn get_freq(&self) -> f64 {
-        unsafe { csound_sys::csoundGetA4(self.csound_ptr()) as f64 }
+    pub fn get_freq(&self) -> Myflt {
+        unsafe { csound_sys::csoundGetA4(self.csound_ptr()) as Myflt }
     }
 
     /// #Returns
@@ -671,7 +678,7 @@ impl Csound {
     #[must_use]
     pub fn get_spin(&self) -> Option<BufferPtr<'_, Writable>> {
         unsafe {
-            let ptr = csound_sys::csoundGetSpin(self.csound_ptr());
+            let ptr = csound_sys::csoundGetSpin(self.csound_ptr()) as *mut Myflt;
             let len = (self.get_ksmps() * self.get_channels(1)) as usize;
             if !ptr.is_null() {
                 return Some(BufferPtr {
@@ -705,7 +712,7 @@ impl Csound {
     #[must_use]
     pub fn get_spout(&self) -> Option<BufferPtr<'_, Readable>> {
         unsafe {
-            let ptr = csound_sys::csoundGetSpout(self.csound_ptr()) as *mut f64;
+            let ptr = csound_sys::csoundGetSpout(self.csound_ptr()) as *mut Myflt;
             let len = (self.get_ksmps() * self.get_channels(0)) as usize;
             if !ptr.is_null() {
                 return Some(BufferPtr {
@@ -730,7 +737,7 @@ impl Csound {
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spout_length = csound.get_ksmps() * csound.get_channels(0); // get output channels
-    /// let mut spout_buffer = vec![0f64; spout_length as usize];
+    /// let mut spout_buffer = vec![0 as Myflt; spout_length as usize];
     /// while !csound.perform_ksmps() {
     ///     // fills your buffer with audio samples you want to pass into csound
     ///     // foo_fill_buffer(&mut spout_buffer);
@@ -742,9 +749,9 @@ impl Csound {
     /// Use [`Csound::get_spout`](struct.Csound.html#method.get_spout) to get a [`BufferPtr`](struct.BufferPtr.html)
     /// object.
     #[deprecated(since = "0.1.5", note = "please use Csound::get_spout object instead")]
-    pub fn read_spout_buffer(&self, output: &mut [f64]) -> Result<usize> {
+    pub fn read_spout_buffer(&self, output: &mut [Myflt]) -> Result<usize> {
         let size = self.get_ksmps() as usize * self.get_channels(0) as usize;
-        let spout = unsafe { csound_sys::csoundGetSpout(self.csound_ptr()) };
+        let spout = unsafe { csound_sys::csoundGetSpout(self.csound_ptr()) as *mut Myflt };
         let mut len = output.len();
         if size < len {
             len = size;
@@ -773,7 +780,7 @@ impl Csound {
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spin_length = csound.get_ksmps() * csound.get_channels(1); // get input channels
-    /// let mut spin_buffer = vec![0f64; spin_length as usize];
+    /// let mut spin_buffer = vec![0 as Myflt; spin_length as usize];
     /// while !csound.perform_ksmps() {
     ///     // fills your buffer with audio samples you want to pass into csound
     ///     // foo_fill_buffer(&mut spin_buffer);
@@ -785,9 +792,9 @@ impl Csound {
     /// Use [`Csound::get_spin`](struct.Csound.html#method.get_spin) to get a [`BufferPtr`](struct.BufferPtr.html)
     /// object.
     #[deprecated(since = "0.1.5", note = "please use Csound::get_spin object instead")]
-    pub fn write_spin_buffer(&self, input: &[f64]) -> Result<usize> {
+    pub fn write_spin_buffer(&self, input: &[Myflt]) -> Result<usize> {
         let size = self.get_ksmps() as usize * self.get_channels(1) as usize;
-        let spin = unsafe { csound_sys::csoundGetSpin(self.csound_ptr()) };
+        let spin = unsafe { csound_sys::csoundGetSpin(self.csound_ptr()) as *mut Myflt };
         let mut len = input.len();
         if size < len {
             len = size;
@@ -950,8 +957,8 @@ impl Csound {
     /// # Returns
     /// The score time beginning at which score events will actually immediately be performed
     /// (see  [`Csound::set_score_offset_seconds`](struct.Csound.html#method.set_score_offset_seconds)).
-    pub fn get_score_offset_seconds(&self) -> f64 {
-        unsafe { csound_sys::csoundGetScoreOffsetSeconds(self.csound_ptr()) as f64 }
+    pub fn get_score_offset_seconds(&self) -> Myflt {
+        unsafe { csound_sys::csoundGetScoreOffsetSeconds(self.csound_ptr()) as Myflt }
     }
 
     /// Csound score events prior to the specified time are not performed.
@@ -959,9 +966,9 @@ impl Csound {
     /// (real-time events will continue to be performed as they are received).
     /// Can be used by external software, such as a VST host, to begin score performance midway through a Csound score,
     ///  for example to repeat a loop in a sequencer or to synchronize other events with the Csound score.
-    pub fn set_score_offset_seconds(&self, offset: f64) {
+    pub fn set_score_offset_seconds(&self, offset: Myflt) {
         unsafe {
-            csound_sys::csoundSetScoreOffsetSeconds(self.csound_ptr(), offset as c_double);
+            csound_sys::csoundSetScoreOffsetSeconds(self.csound_ptr(), offset as Myflt);
         }
     }
 
@@ -1133,7 +1140,7 @@ impl Csound {
     ///  - ControlChannel
     ///    control data (one MYFLT value)
     ///  - AudioChannel
-    ///    audio data (get_ksmps() f64 values)
+    ///    audio data (get_ksmps() MYFLT values)
     ///  - StrChannel:
     ///    string data (u8 values with enough space to store
     ///    get_channel_data_size() characters, including the
@@ -1264,7 +1271,7 @@ impl Csound {
     ///  - ControlChannel
     ///    control data (one MYFLT value)
     ///  - AudioChannel
-    ///    audio data (get_ksmps() f64 values)
+    ///    audio data (get_ksmps() MYFLT values)
     ///  - StrChannel:
     ///    string data (u8 values with enough space to store
     ///    get_channel_data_size() characters, including the
@@ -1382,7 +1389,7 @@ impl Csound {
     pub(crate) fn get_raw_channel_ptr(
         &self,
         name: &str,
-        ptr: *mut *mut f64,
+        ptr: *mut *mut Myflt,
         channel_type: c_int,
     ) -> c_int {
         let cname = match CString::new(name) {
@@ -1510,7 +1517,7 @@ impl Csound {
     /// # Arguments
     /// * `name`  The channel name.
     ///   An error message will be returned if the channel is not a control channel, the channel not exist or if the name is invalid.
-    pub fn get_control_channel(&self, name: &str) -> Result<f64> {
+    pub fn get_control_channel(&self, name: &str) -> Result<Myflt> {
         let cname = CString::new(name)?;
         let mut err: c_int = 0;
         unsafe {
@@ -1518,7 +1525,7 @@ impl Csound {
                 self.csound_ptr(),
                 cname.as_ptr(),
                 &mut err as *mut _,
-            ) as f64;
+            ) as Myflt;
             if (err) == CSOUND_STATUS::CSOUND_SUCCESS {
                 Ok(ret)
             } else {
@@ -1533,7 +1540,7 @@ impl Csound {
     /// Sets the value of a control channel.
     /// # Arguments
     /// * `name`  The channel name.
-    pub fn set_control_channel(&mut self, name: &str, value: f64) -> Result<()> {
+    pub fn set_control_channel(&mut self, name: &str, value: Myflt) -> Result<()> {
         let cname = CString::new(name)?;
         unsafe { csound_sys::csoundSetControlChannel(self.csound_ptr(), cname.as_ptr(), value) };
         Ok(())
@@ -1543,12 +1550,12 @@ impl Csound {
     /// # Arguments
     /// * `name` The channel name.
     /// * `output` The slice where the data contained in the internal audio channel buffer
-    ///   will be copied. Should contain enough memory for ksmps f64 samples.
+    ///   will be copied. Should contain enough memory for ksmps MYFLT samples.
     ///
     /// # Errors
     /// - [`Error::Nul`] if the channel name contains an interior NUL byte
     /// - [`Error::InsufficientCapacity`] if the output buffer is too small
-    pub fn read_audio_channel(&self, name: &str, output: &mut [f64]) -> Result<()> {
+    pub fn read_audio_channel(&self, name: &str, output: &mut [Myflt]) -> Result<()> {
         let ksmps = self.get_ksmps() as usize;
         let cname = CString::new(name)?;
 
@@ -1569,7 +1576,7 @@ impl Csound {
             csound_sys::csoundGetAudioChannel(
                 self.csound_ptr(),
                 cname.as_ptr(),
-                output.as_ptr() as *mut c_double,
+                output.as_mut_ptr(),
             );
         }
         Ok(())
@@ -1583,7 +1590,7 @@ impl Csound {
     /// # Errors
     /// - [`Error::Nul`] if the channel name contains an interior NUL byte
     /// - [`Error::InsufficientCapacity`] if the input data exceeds channel capacity
-    pub fn write_audio_channel(&mut self, name: &str, input: &[f64]) -> Result<()> {
+    pub fn write_audio_channel(&mut self, name: &str, input: &[Myflt]) -> Result<()> {
         let size = self.get_ksmps() as usize * self.get_channels(1) as usize;
         let cname = CString::new(name)?;
 
@@ -1604,7 +1611,7 @@ impl Csound {
             csound_sys::csoundSetAudioChannel(
                 self.csound_ptr(),
                 cname.as_ptr(),
-                input.as_ptr() as *mut c_double,
+                input.as_ptr() as *mut Myflt,
             );
         }
         Ok(())
@@ -1669,7 +1676,7 @@ impl Csound {
     ///
     /// # Arguments
     /// * `event_type` - The type of score event to send.
-    /// * `pfields` - A slice of f64 values containing the p-fields for this event.
+    /// * `pfields` - A slice of Myflt values containing the p-fields for this event.
     ///   For instrument events, this typically includes instrument number, start time, duration,
     ///   and any additional parameters.
     ///
@@ -1689,12 +1696,12 @@ impl Csound {
     ///     // Performance loop
     /// }
     /// ```
-    pub fn send_score_event(&self, event_type: ScoreEventType, pfields: &[f64]) {
+    pub fn send_score_event(&self, event_type: ScoreEventType, pfields: &[Myflt]) {
         unsafe {
             csound_sys::csoundEvent(
                 self.csound_ptr(),
                 event_type.as_i32(),
-                pfields.as_ptr() as *mut c_double,
+                pfields.as_ptr() as *mut Myflt,
                 pfields.len() as c_int,
                 0,
             );
@@ -1708,7 +1715,7 @@ impl Csound {
     ///
     /// # Arguments
     /// * `event_type` - The type of score event to send.
-    /// * `pfields` - A slice of f64 values containing the p-fields for this event.
+    /// * `pfields` - A slice of Myflt values containing the p-fields for this event.
     ///   For instrument events, this typically includes instrument number, start time, duration,
     ///   and any additional parameters.
     ///
@@ -1724,12 +1731,12 @@ impl Csound {
     /// let pfields = [1.0, 0.0, 1.0];
     /// cs.send_score_event_async(ScoreEventType::Instrument, &pfields);
     /// ```
-    pub fn send_score_event_async(&self, event_type: ScoreEventType, pfields: &[f64]) {
+    pub fn send_score_event_async(&self, event_type: ScoreEventType, pfields: &[Myflt]) {
         unsafe {
             csound_sys::csoundEvent(
                 self.csound_ptr(),
                 event_type.as_i32(),
-                pfields.as_ptr() as *mut c_double,
+                pfields.as_ptr() as *mut Myflt,
                 pfields.len() as c_int,
                 1,
             );
@@ -1740,18 +1747,18 @@ impl Csound {
     ///
     /// # Arguments
     /// * `event_type` - The event type as raw i32 (0=instrument, 1=table, 2=end).
-    /// * `pfields` - A slice of f64 values with all the pfields for this event.
+    /// * `pfields` - A slice of Myflt values with all the pfields for this event.
     /// * `async_` - If non-zero, the event is processed asynchronously.
     #[deprecated(
         since = "0.2.0",
         note = "Use `send_score_event` or `send_score_event_async` with `ScoreEventType` instead"
     )]
-    pub fn send_sound_event(&self, event_type: i32, pfields: &[f64], async_: i32) {
+    pub fn send_sound_event(&self, event_type: i32, pfields: &[Myflt], async_: i32) {
         unsafe {
             csound_sys::csoundEvent(
                 self.csound_ptr(),
                 event_type,
-                pfields.as_ptr() as *mut c_double,
+                pfields.as_ptr() as *mut Myflt,
                 pfields.len() as c_int,
                 async_,
             );
@@ -1833,24 +1840,24 @@ impl Csound {
     /// cs.compile_csd("some.csd", 0, 0);
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {
-    ///     let mut table_buff = vec![0f64; cs.table_length(1).unwrap() as usize];
+    ///     let mut table_buff = vec![0 as Myflt; cs.table_length(1).unwrap() as usize];
     ///     // Gets the function table 1
     ///     let mut table = cs.get_table(1).unwrap();
     ///     // Copies the table content into table_buff
     ///     // table.read( table_buff.as_mut_slice() ).unwrap();
     ///     // Do some stuffs
-    ///     // table.write(&table_buff.into_iter().map(|x| x*2.5).collect::<Vec<f64>>().as_mut_slice());
+    ///     // table.write(&table_buff.into_iter().map(|x| x*2.5).collect::<Vec<Myflt>>().as_mut_slice());
     ///     // Do some stuffs
     /// }
     /// ```
     /// see [`Table::read`](struct.Table.html#method.read) or [`Table::write`](struct.Table.html#method.write).
     pub fn get_table(&self, table: TableId) -> Option<Table<'_>> {
-        let mut ptr = ptr::null_mut() as *mut c_double;
+        let mut ptr = ptr::null_mut() as *mut Myflt;
         let length;
         unsafe {
             length = csound_sys::csoundGetTable(
                 self.csound_ptr(),
-                &mut ptr as *mut *mut c_double,
+                &mut ptr as *mut *mut Myflt,
                 table as c_int,
             ) as i32;
         }
@@ -1872,7 +1879,7 @@ impl Csound {
     /// A vector containing the table's arguments.
     /// Note:* the argument list starts with the GEN number and is followed by its parameters.
     /// eg. f 1 0 1024 10 1 0.5 yields the list {10.0,1.0,0.5}.
-    pub fn get_table_args(&self, table: TableId) -> Option<Vec<f64>> {
+    pub fn get_table_args(&self, table: TableId) -> Option<Vec<Myflt>> {
         let slice = self.get_table_args_slice(table)?;
         Some(slice.to_vec())
     }
@@ -1880,18 +1887,18 @@ impl Csound {
     /// Gets the arguments used to construct or define a function table
     /// Similar to [`Csound::get_table_args`](struct.Csound.html#method.get_table_args)
     /// but no memory will be allocated, instead a slice is returned.
-    pub fn get_table_args_slice(&self, table: TableId) -> Option<&[f64]> {
-        let mut ptr = ptr::null_mut() as *mut c_double;
+    pub fn get_table_args_slice(&self, table: TableId) -> Option<&[Myflt]> {
+        let mut ptr = ptr::null_mut() as *mut Myflt;
         unsafe {
             let length = csound_sys::csoundGetTableArgs(
                 self.csound_ptr(),
-                &mut ptr as *mut *mut c_double,
+                &mut ptr as *mut *mut Myflt,
                 table as c_int,
             );
             if length < 0 {
                 None
             } else {
-                Some(slice::from_raw_parts(ptr as *const _, length as usize))
+                Some(slice::from_raw_parts(ptr as *const Myflt, length as usize))
             }
         }
     }
@@ -2020,7 +2027,7 @@ impl Csound {
     /// use csound::Csound;
     ///
     /// let csound = Csound::new().unwrap();
-    /// let circular_buffer = csound.create_circular_buffer::<f64>(1024);
+    /// let circular_buffer = csound.create_circular_buffer::<Myflt>(1024);
     /// ```
     pub fn create_circular_buffer<'a, T: 'a + Copy>(&'a self, len: u32) -> CircularBuffer<'a, T> {
         unsafe {
@@ -2098,7 +2105,7 @@ impl Csound {
     /// to a proper audio device.
     pub fn rt_audio_play_callback<'c, F>(&self, f: F)
     where
-        F: FnMut(&[f64]) + 'c,
+        F: FnMut(&[crate::Myflt]) + 'c,
     {
         unsafe {
             (*(csound_sys::csoundGetHostData(self.csound_ptr()) as *mut CallbackHandler))
@@ -2112,7 +2119,7 @@ impl Csound {
     /// audio module, and pass it into csound.
     pub fn rt_audio_rec_callback<'c, F>(&self, f: F)
     where
-        F: FnMut(&mut [f64]) -> usize + 'c,
+        F: FnMut(&mut [crate::Myflt]) -> usize + 'c,
     {
         unsafe {
             (*(csound_sys::csoundGetHostData(self.csound_ptr()) as *mut CallbackHandler))
@@ -2506,7 +2513,7 @@ pub enum Writable {}
 /// Csound buffer pointer representation.
 /// This struct is build up to manipulate directly csound's buffers.
 pub struct BufferPtr<'a, T> {
-    ptr: *mut f64,
+    ptr: *mut Myflt,
     len: usize,
     phantom: PhantomData<&'a T>,
 }
@@ -2524,7 +2531,7 @@ impl<'a, T> BufferPtr<'a, T> {
     /// * `slice` A mutable slice where the data will be copy
     /// # Returns
     /// The number of elements copied into the slice.
-    pub fn copy_to_slice(&self, slice: &mut [f64]) -> usize {
+    pub fn copy_to_slice(&self, slice: &mut [Myflt]) -> usize {
         let mut len = slice.len();
         let size = self.get_size();
         if size < len {
@@ -2538,7 +2545,7 @@ impl<'a, T> BufferPtr<'a, T> {
 
     /// # Returns
     /// A slice to the buffer internal data
-    pub fn as_slice(&self) -> &[f64] {
+    pub fn as_slice(&self) -> &[Myflt] {
         unsafe { slice::from_raw_parts(self.ptr, self.len) }
     }
 }
@@ -2546,7 +2553,7 @@ impl<'a, T> BufferPtr<'a, T> {
 impl<'a> BufferPtr<'a, Writable> {
     /// # Returns
     /// This buffer pointer as a mutable slice.
-    pub fn as_mut_slice(&mut self) -> &mut [f64] {
+    pub fn as_mut_slice(&mut self) -> &mut [Myflt] {
         unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
     }
 
@@ -2555,7 +2562,7 @@ impl<'a> BufferPtr<'a, Writable> {
     /// * `slice` A slice with samples to copy
     /// # Returns
     /// The number of elements copied into the csound's buffer.
-    pub fn copy_from_slice(&self, slice: &[f64]) -> usize {
+    pub fn copy_from_slice(&self, slice: &[Myflt]) -> usize {
         let mut len = slice.len();
         let size = self.get_size();
         if size < len {
@@ -2570,32 +2577,32 @@ impl<'a> BufferPtr<'a, Writable> {
     /// method used to clear the buffer's data
     pub fn clear(&mut self) {
         for s in self.as_mut_slice() {
-            *s = 0f64;
+            *s = 0.0 as Myflt;
         }
     }
 }
 
-impl<'a, T> AsRef<[f64]> for BufferPtr<'a, T> {
-    fn as_ref(&self) -> &[f64] {
+impl<'a, T> AsRef<[Myflt]> for BufferPtr<'a, T> {
+    fn as_ref(&self) -> &[Myflt] {
         self.as_slice()
     }
 }
 
-impl<'a> AsMut<[f64]> for BufferPtr<'a, Writable> {
-    fn as_mut(&mut self) -> &mut [f64] {
+impl<'a> AsMut<[Myflt]> for BufferPtr<'a, Writable> {
+    fn as_mut(&mut self) -> &mut [Myflt] {
         self.as_mut_slice()
     }
 }
 
 impl<'a, T> Deref for BufferPtr<'a, T> {
-    type Target = [f64];
-    fn deref(&self) -> &[f64] {
+    type Target = [Myflt];
+    fn deref(&self) -> &[Myflt] {
         self.as_slice()
     }
 }
 
 impl<'a> DerefMut for BufferPtr<'a, Writable> {
-    fn deref_mut(&mut self) -> &mut [f64] {
+    fn deref_mut(&mut self) -> &mut [Myflt] {
         self.as_mut_slice()
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,7 @@
 use bitflags::bitflags;
 
+use crate::Myflt;
+
 #[derive(Debug, PartialEq)]
 /// An audio channel identifier
 pub enum AudioChannel {}
@@ -96,8 +98,8 @@ impl Status {
 /// [*outvalue*](http://www.csounds.com/manual/html/outvalue.html) opcodes. Only control and string channels are supported.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChannelData {
-    /// Control channel data (single f64 value).
-    Control(f64),
+    /// Control channel data (single MYFLT value).
+    Control(Myflt),
     /// String channel data.
     String(String),
     /// Unknown channel type.

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,10 @@ pub enum Error {
     #[error("insufficient buffer capacity: expected {expected}, got {actual}")]
     InsufficientCapacity { expected: usize, actual: usize },
 
+    /// MYFLT size mismatch between Rust bindings and linked Csound library.
+    #[error("MYFLT size mismatch: bindings use {expected} bytes, csound reports {actual} bytes")]
+    MyfltMismatch { expected: usize, actual: usize },
+
     /// A channel with the same name but incompatible type already exists.
     /// The contained value is the type of the existing channel.
     #[error("channel type mismatch: existing channel has type {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,5 +143,8 @@ pub use error::{CsoundStatus, Error, Result};
 pub use rtaudio::{CsAudioDevice, CsMidiDevice, RtAudioParams};
 pub use table::{Table, TableId};
 
+/// Csound sample type (MYFLT) as defined by the linked Csound build.
+pub type Myflt = csound_sys::MYFLT;
+
 // Re-export tracing for users who want to configure logging
 pub use tracing;

--- a/src/table.rs
+++ b/src/table.rs
@@ -2,6 +2,7 @@ use core::slice;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
+use crate::Myflt;
 /// A Csound function table identifier.
 ///
 /// Table IDs are user-defined integers that identify function tables in Csound.
@@ -23,9 +24,9 @@ pub type TableId = u32;
 /// [`Csound::table_length`](crate::Csound::table_length) for details on guard points.
 #[derive(Debug)]
 pub struct Table<'a> {
-    pub(crate) ptr: *mut f64,
+    pub(crate) ptr: *mut Myflt,
     pub(crate) length: usize,
-    pub(crate) phantom: PhantomData<&'a f64>,
+    pub(crate) phantom: PhantomData<&'a Myflt>,
 }
 
 impl<'a> Table<'a> {
@@ -39,13 +40,13 @@ impl<'a> Table<'a> {
 
     /// # Returns
     /// A slice representation with the table's internal data
-    pub fn as_slice(&self) -> &[f64] {
+    pub fn as_slice(&self) -> &[Myflt] {
         unsafe { slice::from_raw_parts(self.ptr, self.length) }
     }
 
     /// # Returns
     /// A mutable slice representation with the table's internal data
-    pub fn as_mut_slice(&mut self) -> &mut [f64] {
+    pub fn as_mut_slice(&mut self) -> &mut [Myflt] {
         unsafe { slice::from_raw_parts_mut(self.ptr, self.length) }
     }
 
@@ -64,13 +65,13 @@ impl<'a> Table<'a> {
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {
     ///     let mut table = cs.get_table(1).unwrap();
-    ///     let mut table_buff = vec![0f64; table.len()];
+    ///     let mut table_buff = vec![0 as Myflt; table.len()];
     ///     // copy Table::length elements from the table's internal buffer
     ///     table.copy_to_slice( table_buff.as_mut_slice() );
     ///     // Do some stuffs
     /// }
     /// ```
-    pub fn copy_to_slice(&self, slice: &mut [f64]) -> usize {
+    pub fn copy_to_slice(&self, slice: &mut [Myflt]) -> usize {
         let mut len = slice.len();
         let size = self.get_size();
         if size < len {
@@ -97,15 +98,15 @@ impl<'a> Table<'a> {
     /// cs.start().unwrap();
     /// while cs.perform_ksmps() == false {
     ///     let mut table = cs.get_table(1).unwrap();
-    ///     let mut table_buff = vec![0f64; table.len()];
+    ///     let mut table_buff = vec![0 as Myflt; table.len()];
     ///     // copy Table::length elements from the table's internal buffer
     ///     // table.read( table_buff.as_mut_slice() ).unwrap();
     ///     // Do some stuffs
-    ///     table.copy_from_slice(&table_buff.into_iter().map(|x| x*2.5).collect::<Vec<f64>>().as_mut_slice());
+    ///     table.copy_from_slice(&table_buff.into_iter().map(|x| x*2.5).collect::<Vec<Myflt>>().as_mut_slice());
     ///     // Do some stuffs
     /// }
     /// ```
-    pub fn copy_from_slice(&self, slice: &[f64]) -> usize {
+    pub fn copy_from_slice(&self, slice: &[Myflt]) -> usize {
         let mut len = slice.len();
         let size = self.get_size();
         if size < len {
@@ -118,27 +119,27 @@ impl<'a> Table<'a> {
     }
 }
 
-impl<'a> AsRef<[f64]> for Table<'a> {
-    fn as_ref(&self) -> &[f64] {
+impl<'a> AsRef<[Myflt]> for Table<'a> {
+    fn as_ref(&self) -> &[Myflt] {
         self.as_slice()
     }
 }
 
-impl<'a> AsMut<[f64]> for Table<'a> {
-    fn as_mut(&mut self) -> &mut [f64] {
+impl<'a> AsMut<[Myflt]> for Table<'a> {
+    fn as_mut(&mut self) -> &mut [Myflt] {
         self.as_mut_slice()
     }
 }
 
 impl<'a> Deref for Table<'a> {
-    type Target = [f64];
-    fn deref(&self) -> &[f64] {
+    type Target = [Myflt];
+    fn deref(&self) -> &[Myflt] {
         self.as_slice()
     }
 }
 
 impl<'a> DerefMut for Table<'a> {
-    fn deref_mut(&mut self) -> &mut [f64] {
+    fn deref_mut(&mut self) -> &mut [Myflt] {
         self.as_mut_slice()
     }
 }

--- a/tests/channel_table_message_tests.rs
+++ b/tests/channel_table_message_tests.rs
@@ -7,7 +7,7 @@
 //! - Function tables (create, length, read/write cycles)
 //! - Message buffer (create, drain messages)
 
-use csound::{Csound, MessageType};
+use csound::{Csound, MessageType, Myflt};
 
 /// Creates a Csound instance configured for testing.
 fn create_test_csound() -> Csound {
@@ -57,7 +57,7 @@ fn test_control_channel_roundtrip() {
         .expect("Failed to get control channel");
 
     assert!(
-        (value - 440.0).abs() < f64::EPSILON,
+        (value - 440.0).abs() < Myflt::EPSILON,
         "Control channel roundtrip failed: expected 440.0, got {}",
         value
     );
@@ -80,7 +80,7 @@ fn test_control_channel_multiple_values() {
             .get_control_channel("freq")
             .expect("Failed to get control channel");
         assert!(
-            (actual - expected).abs() < f64::EPSILON,
+            (actual - expected).abs() < Myflt::EPSILON,
             "Control channel mismatch: expected {}, got {}",
             expected,
             actual
@@ -221,21 +221,23 @@ fn test_audio_channel_read_write() {
     let ksmps = cs.get_ksmps() as usize;
 
     // Create input samples (sine wave fragment)
-    let input: Vec<f64> = (0..ksmps).map(|i| (i as f64 * 0.1).sin() * 0.5).collect();
+    let input: Vec<Myflt> = (0..ksmps)
+        .map(|i| ((i as f64 * 0.1).sin() * 0.5) as Myflt)
+        .collect();
 
     // Write to audio input channel
     cs.write_audio_channel("audio_in", &input)
         .expect("Failed to write audio channel");
 
     // Read from audio input channel to verify write
-    let mut output = vec![0.0f64; ksmps];
+    let mut output = vec![0.0 as Myflt; ksmps];
     cs.read_audio_channel("audio_in", &mut output)
         .expect("Failed to read audio channel");
 
     // Verify the data matches
     for (i, (inp, out)) in input.iter().zip(output.iter()).enumerate() {
         assert!(
-            (inp - out).abs() < 1e-10,
+            (inp - out).abs() < (1e-6 as Myflt),
             "Audio channel mismatch at sample {}: expected {}, got {}",
             i,
             inp,
@@ -255,7 +257,7 @@ fn test_audio_channel_read_insufficient_buffer_returns_error() {
     let ksmps = cs.get_ksmps() as usize;
 
     // Try to read into a buffer that's too small
-    let mut small_buffer = vec![0.0f64; ksmps - 1];
+    let mut small_buffer = vec![0.0 as Myflt; ksmps - 1];
     let result = cs.read_audio_channel("audio_in", &mut small_buffer);
 
     assert!(
@@ -277,7 +279,7 @@ fn test_audio_channel_write_oversized_returns_error() {
     let max_size = ksmps * nchnls;
 
     // Try to write more samples than allowed
-    let oversized = vec![0.0f64; max_size + 1];
+    let oversized = vec![0.0 as Myflt; max_size + 1];
     let result = cs.write_audio_channel("audio_in", &oversized);
 
     assert!(
@@ -395,20 +397,20 @@ fn test_table_write_and_read_cycle() {
     let size = table.get_size();
 
     // Create test data
-    let test_data: Vec<f64> = (0..size).map(|i| i as f64 * 0.1).collect();
+    let test_data: Vec<Myflt> = (0..size).map(|i| ((i as f64) * 0.1) as Myflt).collect();
 
     // Write to table using copy_from_slice
     let copied = table.copy_from_slice(&test_data);
     assert_eq!(copied, size, "Should copy all {} elements", size);
 
     // Read back and verify
-    let mut read_back = vec![0.0f64; size];
+    let mut read_back = vec![0.0 as Myflt; size];
     let read_count = table.copy_to_slice(&mut read_back);
     assert_eq!(read_count, size, "Should read all {} elements", size);
 
     for (i, (expected, actual)) in test_data.iter().zip(read_back.iter()).enumerate() {
         assert!(
-            (expected - actual).abs() < f64::EPSILON,
+            (expected - actual).abs() < Myflt::EPSILON,
             "Table data mismatch at index {}: expected {}, got {}",
             i,
             expected,
@@ -431,16 +433,16 @@ fn test_table_direct_slice_access() {
     {
         let slice = table.as_mut_slice();
         for (i, val) in slice.iter_mut().enumerate() {
-            *val = (i as f64).powi(2);
+            *val = ((i as f64).powi(2)) as Myflt;
         }
     }
 
     // Read back via immutable slice
     let slice = table.as_slice();
     for (i, val) in slice.iter().enumerate() {
-        let expected = (i as f64).powi(2);
+        let expected = ((i as f64).powi(2)) as Myflt;
         assert!(
-            (val - expected).abs() < f64::EPSILON,
+            (val - expected).abs() < Myflt::EPSILON,
             "Direct slice access mismatch at {}: expected {}, got {}",
             i,
             expected,
@@ -480,12 +482,12 @@ fn test_get_table_args() {
         "Should have at least GEN and one parameter"
     );
     assert!(
-        (args[0] - 10.0).abs() < f64::EPSILON,
+        (args[0] - 10.0).abs() < Myflt::EPSILON,
         "GEN should be 10, got {}",
         args[0]
     );
     assert!(
-        (args[1] - 1.0).abs() < f64::EPSILON,
+        (args[1] - 1.0).abs() < Myflt::EPSILON,
         "First harmonic should be 1, got {}",
         args[1]
     );
@@ -604,17 +606,17 @@ fn test_get_channel_hints() {
         .expect("Failed to get channel hints");
 
     assert!(
-        (hints.dflt - 0.5).abs() < f64::EPSILON,
+        (hints.dflt - 0.5).abs() < Myflt::EPSILON,
         "Default should be 0.5, got {}",
         hints.dflt
     );
     assert!(
-        hints.min.abs() < f64::EPSILON,
+        hints.min.abs() < Myflt::EPSILON,
         "Min should be 0.0, got {}",
         hints.min
     );
     assert!(
-        (hints.max - 1.0).abs() < f64::EPSILON,
+        (hints.max - 1.0).abs() < Myflt::EPSILON,
         "Max should be 1.0, got {}",
         hints.max
     );


### PR DESCRIPTION
  - interpret rtplay/rtrecord nbytes as bytes and convert to element count
  - return bytes from rtrecord callback and use MYFLT in RT callback signatures
  - export MYFLT from csound-sys with CSOUND_USE_DOUBLE cfg
  - make Myflt a public alias and propagate across channels/tables/buffers/events
  - add runtime MYFLT size mismatch error in Csound::new
  - update tests/docs for Myflt and fix clippy test warning