### PR TITLE
fix(buffer): guard message buffer APIs when no buffer is present

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -168,7 +168,7 @@ impl<'a> Callbacks<'a> {
         F: FnMut(&RtAudioParams) -> Status + 'a,
     {
         unsafe {
-            self.play_open_cb = Some(Box::new(cb));
+            self.rec_open_cb = Some(Box::new(cb));
             raw::csoundSetRecopenCallback(csound, Some(Trampoline::recOpenCallback));
         }
     }
@@ -722,11 +722,24 @@ pub mod Trampoline {
                         *(channelValuePtr as *mut Myflt) = data;
                     }
                     ChannelData::String(s) => {
-                        let len = s.len();
-                        if let Ok(c_str) = CString::new(s)
-                            && raw::csoundGetChannelDatasize(csound, channelName) as usize <= len
-                        {
-                            memcpy(channelValuePtr, c_str.as_ptr() as *mut c_void, len);
+                        if let Ok(c_str) = CString::new(s) {
+                            let bytes = c_str.as_bytes_with_nul();
+                            let datasize =
+                                raw::csoundGetChannelDatasize(csound, channelName) as usize;
+                            if datasize < bytes.len() {
+                                tracing::warn!(
+                                    channel = name,
+                                    datasize,
+                                    required = bytes.len(),
+                                    "string channel buffer too small"
+                                );
+                                return;
+                            }
+                            memcpy(
+                                channelValuePtr,
+                                bytes.as_ptr() as *const c_void,
+                                bytes.len(),
+                            );
                         }
                     }
                     _ => {}

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1026,8 +1026,15 @@ impl Csound {
     /// # Returns
     /// The first message from the buffer.
     pub fn get_first_message(&self) -> Option<String> {
+        if !self.has_message_buffer() {
+            return None;
+        }
         unsafe {
-            match CStr::from_ptr(csound_sys::csoundGetFirstMessage(self.csound_ptr())).to_str() {
+            let ptr = csound_sys::csoundGetFirstMessage(self.csound_ptr());
+            if ptr.is_null() {
+                return None;
+            }
+            match CStr::from_ptr(ptr).to_str() {
                 Ok(m) => Some(m.to_owned()),
                 _ => None,
             }
@@ -1036,10 +1043,16 @@ impl Csound {
 
     /// # Returns
     /// The attribute parameter ([`MessageType`](enum.MessageType.html)) of the first message in the buffer.
-    pub fn get_first_message_attr(&self) -> MessageType {
-        unsafe {
-            MessageType::from(csound_sys::csoundGetFirstMessageAttr(self.csound_ptr()) as u32)
+    pub fn get_first_message_attr(&self) -> Option<MessageType> {
+        if !self.has_message_buffer() {
+            return None;
         }
+        if unsafe { csound_sys::csoundGetMessageCnt(self.csound_ptr()) } <= 0 {
+            return None;
+        }
+        Some(unsafe {
+            MessageType::from(csound_sys::csoundGetFirstMessageAttr(self.csound_ptr()) as u32)
+        })
     }
 
     /// Removes the first message from the buffer.
@@ -1051,8 +1064,16 @@ impl Csound {
 
     /// # Returns
     /// The number of pending messages in the buffer.
-    pub fn get_message_count(&self) -> u32 {
-        unsafe { csound_sys::csoundGetMessageCnt(self.csound_ptr()) as u32 }
+    pub fn get_message_count(&self) -> Option<u32> {
+        if !self.has_message_buffer() {
+            return None;
+        }
+        let count = unsafe { csound_sys::csoundGetMessageCnt(self.csound_ptr()) };
+        if count < 0 {
+            None
+        } else {
+            Some(count as u32)
+        }
     }
 
     /* Engine general Channels, Control and Events implementations ********************************************** */
@@ -1665,9 +1686,12 @@ impl Csound {
     /// - [`Error::Nul`] if the channel name contains an interior NUL byte
     pub fn get_channel_data_size(&self, name: &str) -> Result<usize> {
         let cname = CString::new(name)?;
-        Ok(unsafe {
-            csound_sys::csoundGetChannelDatasize(self.csound_ptr(), cname.as_ptr()) as usize
-        })
+        let size = unsafe { csound_sys::csoundGetChannelDatasize(self.csound_ptr(), cname.as_ptr()) };
+        if size <= 0 {
+            tracing::error!(channel = name, "channel not found or has invalid data size");
+            return Err(Error::NotFound("channel does not exist"));
+        }
+        Ok(size as usize)
     }
 
     /// Sends a score event to Csound synchronously.

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1069,11 +1069,7 @@ impl Csound {
             return None;
         }
         let count = unsafe { csound_sys::csoundGetMessageCnt(self.csound_ptr()) };
-        if count < 0 {
-            None
-        } else {
-            Some(count as u32)
-        }
+        if count < 0 { None } else { Some(count as u32) }
     }
 
     /* Engine general Channels, Control and Events implementations ********************************************** */
@@ -1686,7 +1682,8 @@ impl Csound {
     /// - [`Error::Nul`] if the channel name contains an interior NUL byte
     pub fn get_channel_data_size(&self, name: &str) -> Result<usize> {
         let cname = CString::new(name)?;
-        let size = unsafe { csound_sys::csoundGetChannelDatasize(self.csound_ptr(), cname.as_ptr()) };
+        let size =
+            unsafe { csound_sys::csoundGetChannelDatasize(self.csound_ptr(), cname.as_ptr()) };
         if size <= 0 {
             tracing::error!(channel = name, "channel not found or has invalid data size");
             return Err(Error::NotFound("channel does not exist"));

--- a/tests/channel_table_message_tests.rs
+++ b/tests/channel_table_message_tests.rs
@@ -513,7 +513,7 @@ fn test_message_buffer_create_and_drain() {
 
     // Drain messages using count to avoid calling get_first_message on empty buffer
     let mut messages = Vec::new();
-    while cs.get_message_count() > 0 {
+    while cs.get_message_count().unwrap_or(0) > 0 {
         if let Some(msg) = cs.get_first_message() {
             messages.push(msg);
         }
@@ -522,7 +522,7 @@ fn test_message_buffer_create_and_drain() {
 
     // After draining, count should be 0
     assert_eq!(
-        cs.get_message_count(),
+        cs.get_message_count().unwrap_or(0),
         0,
         "Message buffer should be empty after draining"
     );
@@ -540,7 +540,7 @@ fn test_message_buffer_attributes() {
     let _ = cs.start();
 
     // Check that we can get message attributes
-    if cs.get_message_count() > 0 {
+    if cs.get_message_count().unwrap_or(0) > 0 {
         let _attr = cs.get_first_message_attr();
         // Just verify it returns without panicking - any MessageType variant is valid
     }


### PR DESCRIPTION
  - return Option for message count and first-message attr
  - avoid null pointer deref from csoundGetFirstMessage
  - update message buffer tests to handle None safely