### PR TITLE
tighten channel writes, buffer copies, and circular buffer creation

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -948,10 +948,25 @@ pub mod Trampoline {
 #[cfg(test)]
 mod tests {
     use super::Trampoline;
-    use crate::{Csound, Myflt};
-    use libc::c_int;
+    use crate::{ChannelData, Csound, Myflt};
+    use libc::{c_int, c_void};
+    use std::ffi::CString;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static STRING_CHANNEL_ORC: &str = r#"
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+
+chn_S "message", 1  ; input string channel
+
+instr 1
+  Smsg chnget "message"
+  prints Smsg
+endin
+"#;
 
     #[test]
     fn rtplay_callback_nbytes_is_bytes_not_elements() {
@@ -978,6 +993,106 @@ mod tests {
             actual, expected,
             "rtplayCallback should pass a slice length derived from bytes (expected {}), got {}",
             expected, actual
+        );
+    }
+
+    #[test]
+    fn rtrecord_callback_nbytes_is_bytes_not_elements() {
+        let cs = Csound::new().expect("Failed to create Csound instance");
+
+        let seen_len = Arc::new(AtomicUsize::new(0));
+        let seen_len_clone = Arc::clone(&seen_len);
+
+        cs.rt_audio_rec_callback(move |buffer: &mut [Myflt]| {
+            seen_len_clone.store(buffer.len(), Ordering::SeqCst);
+            buffer.len()
+        });
+
+        let nbytes: usize = 64;
+        let expected = nbytes / std::mem::size_of::<Myflt>();
+        let mut buffer = vec![0.0 as Myflt; expected];
+
+        let csound_ptr = cs.engine.csound.as_ptr();
+        let written = Trampoline::rtrecordCallback(
+            csound_ptr,
+            buffer.as_mut_ptr(),
+            nbytes as c_int,
+        );
+
+        let actual = seen_len.load(Ordering::SeqCst);
+        assert_eq!(
+            actual, expected,
+            "rtrecordCallback should pass a slice length derived from bytes (expected {}), got {}",
+            expected, actual
+        );
+        assert_eq!(
+            written,
+            nbytes as c_int,
+            "rtrecordCallback should return written bytes"
+        );
+    }
+
+    #[test]
+    fn input_channel_callback_string_copy() {
+        let mut cs = Csound::new().expect("Failed to create Csound instance");
+        cs.set_option("-n").expect("Failed to set -n option");
+        cs.set_option("-d").expect("Failed to set -d option");
+        cs.set_option("-m0").expect("Failed to set -m0 option");
+
+        cs.compile_orc(STRING_CHANNEL_ORC, 0)
+            .expect("Failed to compile orchestra");
+        cs.start().expect("Failed to start Csound");
+
+        cs.input_channel_callback(|name| {
+            if name == "message" {
+                ChannelData::String("abc".to_owned())
+            } else {
+                ChannelData::Unknown
+            }
+        });
+
+        let datasize = cs
+            .get_channel_data_size("message")
+            .expect("Failed to get channel data size");
+        let mut buffer = vec![0u8; datasize];
+        let cname = CString::new("message").unwrap();
+
+        Trampoline::inputChannelCallback(
+            cs.engine.csound.as_ptr(),
+            cname.as_ptr(),
+            buffer.as_mut_ptr() as *mut c_void,
+            std::ptr::null(),
+        );
+
+        assert_eq!(&buffer[..4], b"abc\0", "string should be NUL-terminated");
+
+        // Keep performance bounded: run a short score with an explicit end event and cap iterations.
+        cs.send_string_event("i1 0 0.01\ne", 0)
+            .expect("Failed to send score event");
+        let mut remaining = 256;
+        while remaining > 0 && !cs.perform_ksmps() {
+            remaining -= 1;
+        }
+        assert!(
+            remaining > 0,
+            "performance did not finish within the iteration cap"
+        );
+    }
+
+    #[test]
+    fn message_buffer_uninitialized_returns_none() {
+        let cs = Csound::new().expect("Failed to create Csound instance");
+        assert!(
+            cs.get_first_message().is_none(),
+            "get_first_message should return None when no buffer is created"
+        );
+        assert!(
+            cs.get_first_message_attr().is_none(),
+            "get_first_message_attr should return None when no buffer is created"
+        );
+        assert!(
+            cs.get_message_count().is_none(),
+            "get_message_count should return None when no buffer is created"
         );
     }
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1013,11 +1013,8 @@ endin
         let mut buffer = vec![0.0 as Myflt; expected];
 
         let csound_ptr = cs.engine.csound.as_ptr();
-        let written = Trampoline::rtrecordCallback(
-            csound_ptr,
-            buffer.as_mut_ptr(),
-            nbytes as c_int,
-        );
+        let written =
+            Trampoline::rtrecordCallback(csound_ptr, buffer.as_mut_ptr(), nbytes as c_int);
 
         let actual = seen_len.load(Ordering::SeqCst);
         assert_eq!(
@@ -1026,15 +1023,14 @@ endin
             expected, actual
         );
         assert_eq!(
-            written,
-            nbytes as c_int,
+            written, nbytes as c_int,
             "rtrecordCallback should return written bytes"
         );
     }
 
     #[test]
     fn input_channel_callback_string_copy() {
-        let mut cs = Csound::new().expect("Failed to create Csound instance");
+        let cs = Csound::new().expect("Failed to create Csound instance");
         cs.set_option("-n").expect("Failed to set -n option");
         cs.set_option("-d").expect("Failed to set -d option");
         cs.set_option("-m0").expect("Failed to set -m0 option");

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,9 +1,11 @@
+use std::ffi::CString;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::slice;
 
 use crate::Myflt;
 use crate::enums::{AudioChannel, ControlChannel, ControlChannelType, StrChannel};
+use crate::error::{Error, Result};
 
 /// Indicates the channel behavior.
 // Unknown(u32) preserves unrecognized values from the C API, keeping
@@ -370,16 +372,30 @@ impl<'a> InputChannel<'a, StrChannel> {
         unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr() as *mut u8, self.len) }
     }
 
-    /// Writes bytes to the string channel.
+    /// Writes a Rust string to the channel, ensuring NUL termination and zeroing the remainder.
     ///
-    /// If the input slice is longer than the channel buffer,
-    /// only `len()` bytes will be copied.
-    pub fn write(&self, bytes: &[u8]) {
-        let copy_len = bytes.len().min(self.len);
+    /// # Errors
+    /// - [`Error::Nul`] if the string contains an interior NUL byte
+    /// - [`Error::InsufficientCapacity`] if the channel buffer is too small
+    pub fn write_str(&self, value: &str) -> Result<()> {
+        let cstr = CString::new(value)?;
+        let bytes = cstr.as_bytes_with_nul();
+        if bytes.len() > self.len {
+            return Err(Error::InsufficientCapacity {
+                expected: bytes.len(),
+                actual: self.len,
+            });
+        }
+
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
-            std::ptr::copy_nonoverlapping(bytes.as_ptr(), self.ptr.as_ptr() as *mut u8, copy_len);
+            let dst = self.ptr.as_ptr() as *mut u8;
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, bytes.len());
+            if self.len > bytes.len() {
+                std::ptr::write_bytes(dst.add(bytes.len()), 0, self.len - bytes.len());
+            }
         }
+        Ok(())
     }
 }
 

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1602,26 +1602,35 @@ impl Csound {
     /// Writes data into an audio channel buffer.
     /// # Arguments
     /// * `name` The channel name.
-    /// * `input` The slice with data to be copied into the audio channel buffer. Could contain up to ksmps samples.
+    /// * `input` The slice with data to be copied into the audio channel buffer. Must contain at least ksmps samples.
+    ///   If more than ksmps samples are provided, the extra data will be ignored.
     ///
     /// # Errors
     /// - [`Error::Nul`] if the channel name contains an interior NUL byte
     /// - [`Error::InsufficientCapacity`] if the input data exceeds channel capacity
     pub fn write_audio_channel(&mut self, name: &str, input: &[Myflt]) -> Result<()> {
-        let size = self.get_ksmps() as usize * self.get_channels(1) as usize;
+        let size = self.get_ksmps() as usize;
         let cname = CString::new(name)?;
 
-        if input.len() > size {
+        if input.len() < size {
             tracing::error!(
                 channel = name,
-                max_size = size,
+                expected = size,
                 actual = input.len(),
-                "audio channel write data exceeds capacity"
+                "audio channel write buffer too small"
             );
             return Err(Error::InsufficientCapacity {
                 expected: size,
                 actual: input.len(),
             });
+        }
+        if input.len() > size {
+            tracing::warn!(
+                channel = name,
+                expected = size,
+                actual = input.len(),
+                "audio channel write buffer larger than ksmps; extra data will be ignored"
+            );
         }
 
         unsafe {
@@ -2042,26 +2051,32 @@ impl Csound {
     /// # Arguments
     /// * `len` The buffer length.
     /// # Returns
-    /// A CircularBuffer
+    /// A [`CircularBuffer`], or an error if allocation fails.
     /// # Example
     /// ```ignore
     /// use csound::Csound;
     ///
     /// let csound = Csound::new().unwrap();
-    /// let circular_buffer = csound.create_circular_buffer::<Myflt>(1024);
+    /// let circular_buffer = csound.create_circular_buffer::<Myflt>(1024).unwrap();
     /// ```
-    pub fn create_circular_buffer<'a, T: 'a + Copy>(&'a self, len: u32) -> CircularBuffer<'a, T> {
+    pub fn create_circular_buffer<'a, T: 'a + Copy>(
+        &'a self,
+        len: u32,
+    ) -> Result<CircularBuffer<'a, T>> {
         unsafe {
             let ptr: *mut T = csound_sys::csoundCreateCircularBuffer(
                 self.csound_ptr(),
                 len as c_int,
                 mem::size_of::<T>() as c_int,
             ) as *mut T;
-            CircularBuffer {
+            if ptr.is_null() {
+                return Err(Error::Memory);
+            }
+            Ok(CircularBuffer {
                 csound: self.csound_ptr(),
                 ptr,
                 phantom: PhantomData,
-            }
+            })
         }
     }
 
@@ -2553,15 +2568,9 @@ impl<'a, T> BufferPtr<'a, T> {
     /// # Returns
     /// The number of elements copied into the slice.
     pub fn copy_to_slice(&self, slice: &mut [Myflt]) -> usize {
-        let mut len = slice.len();
-        let size = self.get_size();
-        if size < len {
-            len = size;
-        }
-        unsafe {
-            std::ptr::copy(self.ptr, slice.as_mut_ptr(), len);
-            len
-        }
+        let len = slice.len().min(self.get_size());
+        slice[..len].copy_from_slice(&self.as_slice()[..len]);
+        len
     }
 
     /// # Returns
@@ -2584,22 +2593,18 @@ impl<'a> BufferPtr<'a, Writable> {
     /// # Returns
     /// The number of elements copied into the csound's buffer.
     pub fn copy_from_slice(&self, slice: &[Myflt]) -> usize {
-        let mut len = slice.len();
-        let size = self.get_size();
-        if size < len {
-            len = size;
-        }
+        let len = slice.len().min(self.get_size());
+        // SAFETY: pointer is valid for the buffer lifetime; length is bounded by buffer size.
         unsafe {
-            std::ptr::copy(slice.as_ptr(), self.ptr, len);
-            len
+            let dst = slice::from_raw_parts_mut(self.ptr, len);
+            dst.copy_from_slice(&slice[..len]);
         }
+        len
     }
 
     /// method used to clear the buffer's data
     pub fn clear(&mut self) {
-        for s in self.as_mut_slice() {
-            *s = 0.0 as Myflt;
-        }
+        self.as_mut_slice().fill(0.0);
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -72,15 +72,9 @@ impl<'a> Table<'a> {
     /// }
     /// ```
     pub fn copy_to_slice(&self, slice: &mut [Myflt]) -> usize {
-        let mut len = slice.len();
-        let size = self.get_size();
-        if size < len {
-            len = size;
-        }
-        unsafe {
-            std::ptr::copy(self.ptr, slice.as_mut_ptr(), len);
-            len
-        }
+        let len = slice.len().min(self.get_size());
+        slice[..len].copy_from_slice(&self.as_slice()[..len]);
+        len
     }
 
     /// method used to copy data into the table internal buffer
@@ -107,15 +101,13 @@ impl<'a> Table<'a> {
     /// }
     /// ```
     pub fn copy_from_slice(&self, slice: &[Myflt]) -> usize {
-        let mut len = slice.len();
-        let size = self.get_size();
-        if size < len {
-            len = size;
-        }
+        let len = slice.len().min(self.get_size());
+        // SAFETY: pointer is valid for the table lifetime; length is bounded by table size.
         unsafe {
-            std::ptr::copy(slice.as_ptr(), self.ptr, len);
-            len
+            let dst = slice::from_raw_parts_mut(self.ptr, len);
+            dst.copy_from_slice(&slice[..len]);
         }
+        len
     }
 }
 

--- a/tests/channel_table_message_tests.rs
+++ b/tests/channel_table_message_tests.rs
@@ -267,7 +267,7 @@ fn test_audio_channel_read_insufficient_buffer_returns_error() {
 }
 
 #[test]
-fn test_audio_channel_write_oversized_returns_error() {
+fn test_audio_channel_write_undersized_returns_error() {
     let mut cs = create_test_csound();
 
     cs.compile_orc(AUDIO_CHANNEL_ORC, 0)
@@ -275,16 +275,14 @@ fn test_audio_channel_write_oversized_returns_error() {
     cs.start().expect("Failed to start Csound");
 
     let ksmps = cs.get_ksmps() as usize;
-    let nchnls = cs.get_channels(1) as usize;
-    let max_size = ksmps * nchnls;
 
-    // Try to write more samples than allowed
-    let oversized = vec![0.0 as Myflt; max_size + 1];
-    let result = cs.write_audio_channel("audio_in", &oversized);
+    // Try to write fewer samples than required
+    let undersized = vec![0.0 as Myflt; ksmps - 1];
+    let result = cs.write_audio_channel("audio_in", &undersized);
 
     assert!(
         result.is_err(),
-        "Writing oversized audio channel should return error"
+        "Writing undersized audio channel should return error"
     );
 }
 


### PR DESCRIPTION
- require >= ksmps for audio channel writes (warn on extra data)
- add write_str for string channels
-  make circular buffer creation fallible
- use copy_from_slice for table/buffer copies
- add callback/message buffer tests