### PR TITLE
feat!: make channel pointer access lock-guarded and fix string channels

### DIFF
--- a/examples/src/channel_bench.rs
+++ b/examples/src/channel_bench.rs
@@ -1,0 +1,100 @@
+use csound::{ControlChannel, Csound, InputChannel, Myflt};
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+static ORC: &str = r#"
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+
+chn_k "bench_control", 1
+
+instr 1
+  gkbench chnget "bench_control"
+endin
+"#;
+
+fn main() {
+    let iterations = std::env::args()
+        .nth(1)
+        .and_then(|arg| arg.parse::<u64>().ok())
+        .unwrap_or(1_000_000);
+
+    let cs = Csound::new().expect("Failed to create Csound instance");
+    cs.set_option("-n").expect("Failed to set -n option");
+    cs.set_option("-d").expect("Failed to set -d option");
+    cs.set_option("-m0").expect("Failed to set -m0 option");
+    cs.compile_orc(ORC, 0)
+        .expect("Failed to compile orchestra");
+    cs.start().expect("Failed to start Csound");
+    cs.send_string_event("i1 0 3600", 0)
+        .expect("Failed to start instrument");
+
+    let channel_name = "bench_control";
+    let writer = cs
+        .get_input_channel::<ControlChannel>(channel_name)
+        .expect("Failed to get input channel");
+
+    println!("iterations: {}", iterations);
+    println!("mode: locked vs unsafe (single-thread)");
+
+    let locked_write_read = bench_locked_write_read(&cs, &writer, iterations);
+    print_result(
+        "locked write+read (single-thread)",
+        iterations,
+        locked_write_read,
+    );
+
+    let unsafe_write_read = bench_unsafe_write_read(&cs, &writer, iterations);
+    print_result(
+        "unsafe write+read (single-thread)",
+        iterations,
+        unsafe_write_read,
+    );
+
+}
+
+fn bench_locked_write_read(
+    cs: &Csound,
+    channel: &InputChannel<'_, ControlChannel>,
+    iterations: u64,
+) -> Duration {
+    let start = Instant::now();
+    let mut sum = 0.0;
+    for i in 0..iterations {
+        let mut guard = channel.lock();
+        let value = black_box(i as Myflt);
+        guard.set(value);
+        sum += guard.get();
+        cs.perform_ksmps();
+    }
+    black_box(sum);
+    start.elapsed()
+}
+
+fn bench_unsafe_write_read(
+    cs: &Csound,
+    channel: &InputChannel<'_, ControlChannel>,
+    iterations: u64,
+) -> Duration {
+    let start = Instant::now();
+    let mut sum = 0.0;
+    for i in 0..iterations {
+        let value = black_box(i as Myflt);
+        // SAFETY: single-threaded access for benchmarking.
+        unsafe {
+            channel.set(value);
+            sum += channel.get();
+        }
+        cs.perform_ksmps();
+    }
+    black_box(sum);
+    start.elapsed()
+}
+
+fn print_result(label: &str, iterations: u64, elapsed: Duration) {
+    let nanos = elapsed.as_nanos() as f64;
+    let per_op = nanos / iterations as f64;
+    println!("{label}: {elapsed:?} total, {per_op:.2} ns/op");
+}

--- a/examples/src/example10.rs
+++ b/examples/src/example10.rs
@@ -52,7 +52,7 @@ impl<'a, T: RandomFunc> Updater<'a, T> {
     }
 
     fn update(&mut self) {
-        self.channel.set(self.data.update());
+        self.channel.lock().set(self.data.update());
     }
 }
 

--- a/examples/src/example7.rs
+++ b/examples/src/example7.rs
@@ -81,7 +81,7 @@ static ORC: &str = "sr=44100
 endin";
 
 fn main() {
-    let mut cs = Csound::new().expect("Failed to create Csound instance");
+    let cs = Csound::new().expect("Failed to create Csound instance");
 
     // Using SetOption() to configure Csound
     // Note: use only one commandline flag at a time

--- a/examples/src/example8.rs
+++ b/examples/src/example8.rs
@@ -103,7 +103,7 @@ fn main() {
 
     // Main performance loop - perform one block at a time
     while !cs.perform_ksmps() {
-        amp_channel.write(amp.tick());
-        freq_channel.write(freq.tick());
+        amp_channel.lock().write(amp.tick());
+        freq_channel.lock().write(freq.tick());
     }
 }

--- a/examples/src/example9.rs
+++ b/examples/src/example9.rs
@@ -101,7 +101,7 @@ fn main() {
 
     // Main performance loop - perform one block at a time
     while !cs.perform_ksmps() {
-        amp_channel.write(amp.tick());
-        freq_channel.write(freq.tick());
+        amp_channel.lock().write(amp.tick());
+        freq_channel.lock().write(freq.tick());
     }
 }

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -653,7 +653,7 @@ impl<'a> OutputChannel<'a, StrChannel> {
         unsafe { CStr::from_ptr(data).to_bytes() }
     }
 
-    /// Reads the string channel's bytes (alias for `as_slice`).
+    /// Reads the string channel's raw bytes (alias for `as_slice`).
     ///
     /// # Safety
     /// Caller must ensure the channel is locked or otherwise synchronized.
@@ -671,11 +671,12 @@ impl<'a> ChannelLock<'a, InputChannel<'a, StrChannel>> {
         unsafe { self.channel.len_bytes() }
     }
 
-    /// Returns an immutable slice of the string channel's bytes.
+    /// Returns the string channel's content as a `&str`.
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_str(&self) -> Result<&str> {
         // SAFETY: channel is locked by this guard
-        unsafe { self.channel.as_slice() }
+        let bytes = unsafe { self.channel.as_slice() };
+        Ok(std::str::from_utf8(bytes)?)
     }
 
     /// Writes a Rust string to the channel, ensuring NUL termination and zeroing the remainder.
@@ -694,16 +695,17 @@ impl<'a> ChannelLock<'a, OutputChannel<'a, StrChannel>> {
         unsafe { self.channel.len_bytes() }
     }
 
-    /// Returns an immutable slice of the string channel's bytes.
+    /// Returns the string channel's content as a `&str`.
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
+    pub fn as_str(&self) -> Result<&str> {
         // SAFETY: channel is locked by this guard
-        unsafe { self.channel.as_slice() }
+        let bytes = unsafe { self.channel.as_slice() };
+        Ok(std::str::from_utf8(bytes)?)
     }
 
-    /// Reads the string channel's bytes (alias for `as_slice`).
+    /// Reads the string channel's content as a `&str`.
     #[inline]
-    pub fn read(&self) -> &[u8] {
-        self.as_slice()
+    pub fn read(&self) -> Result<&str> {
+        self.as_str()
     }
 }

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -14,6 +14,12 @@ mod sealed {
     pub trait Sealed {}
 }
 
+// Channel Access types
+// use to define input channels and output channels
+// allong with their variance
+type InputPhantom<'a, T> = &'a mut T;
+type OutputPhantom<'a, T> = &'a T;
+
 /// Indicates the channel behavior.
 // Unknown(u32) preserves unrecognized values from the C API, keeping
 // forward-compatibility as csound adds new behavior types.
@@ -166,13 +172,12 @@ impl PvsDataExt {
 /// This struct wraps a pointer to csound's internal channel buffer.
 /// Use the explicit `get()`, `set()`, `write()`, and slice accessor methods
 /// rather than relying on implicit dereferencing.
-#[derive(Debug)]
+///
+/// The lifetime of this handle is tied to the originating [`Csound`]
+/// instance that created it. Dropping the `Csound` invalidates the
+/// underlying channel pointer.
 pub struct InputChannel<'a, T: IsChannel> {
-    csound: NonNull<csound_sys::CSOUND>,
-    name: CString,
-    ptr: NonNull<T::Raw>,
-    len: usize,
-    phantom: PhantomData<&'a mut T>,
+    inner: ChannelCore<T, InputPhantom<'a, T>>,
 }
 
 /// Csound output channel - allows reading data from csound.
@@ -180,13 +185,78 @@ pub struct InputChannel<'a, T: IsChannel> {
 /// This struct wraps a pointer to csound's internal channel buffer.
 /// Use the explicit `get()`, `read()`, and slice accessor methods
 /// rather than relying on implicit dereferencing.
-#[derive(Debug)]
+///
+/// The lifetime of this handle is tied to the originating [`Csound`]
+/// instance that created it. Dropping the `Csound` invalidates the
+/// underlying channel pointer.
 pub struct OutputChannel<'a, T: IsChannel> {
+    inner: ChannelCore<T, OutputPhantom<'a, T>>,
+}
+
+struct ChannelCore<T: IsChannel, P> {
     csound: NonNull<csound_sys::CSOUND>,
     name: CString,
     ptr: NonNull<T::Raw>,
     len: usize,
-    phantom: PhantomData<&'a T>,
+    phantom: PhantomData<P>,
+}
+
+impl<'a, T: IsChannel> std::fmt::Debug for InputChannel<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ptr = self.inner.ptr.as_ptr();
+        f.debug_struct("InputChannel")
+            .field("name", &self.inner.name)
+            .field("ptr", &ptr)
+            .field("len", &self.inner.len)
+            .field("channel_type", &T::c_type())
+            .finish()
+    }
+}
+
+impl<'a, T: IsChannel> std::fmt::Debug for OutputChannel<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ptr = self.inner.ptr.as_ptr();
+        f.debug_struct("OutputChannel")
+            .field("name", &self.inner.name)
+            .field("ptr", &ptr)
+            .field("len", &self.inner.len)
+            .field("channel_type", &T::c_type())
+            .finish()
+    }
+}
+
+impl<T: IsChannel, P> ChannelCore<T, P> {
+    /// Creates a new ChannelCore from a raw pointer.
+    ///
+    /// # Safety
+    /// The pointer must be valid and point to memory owned by csound.
+    unsafe fn new(
+        csound: *mut csound_sys::CSOUND,
+        name: CString,
+        ptr: *mut T::Raw,
+        len: usize,
+    ) -> Option<Self> {
+        let csound = NonNull::new(csound)?;
+        NonNull::new(ptr).map(|ptr| ChannelCore {
+            csound,
+            name,
+            ptr,
+            len,
+            phantom: PhantomData,
+        })
+    }
+
+    /// Returns the length of the channel buffer.
+    #[inline]
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the channel buffer is empty.
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 /// Guard that locks a channel for safe pointer access.
@@ -223,6 +293,10 @@ impl<C> Drop for ChannelLock<'_, C> {
 // and access is synchronized through csound's own mechanisms.
 unsafe impl<T: IsChannel> Send for InputChannel<'_, T> {}
 unsafe impl<T: IsChannel> Send for OutputChannel<'_, T> {}
+// SAFETY: Shared access is safe because channel reads/writes are synchronized
+// via csound's channel lock (or require unsafe caller synchronization).
+unsafe impl<T: IsChannel> Sync for InputChannel<'_, T> {}
+unsafe impl<T: IsChannel> Sync for OutputChannel<'_, T> {}
 
 impl<'a, T: IsChannel> InputChannel<'a, T> {
     /// Creates a new InputChannel from a raw pointer.
@@ -235,14 +309,7 @@ impl<'a, T: IsChannel> InputChannel<'a, T> {
         ptr: *mut T::Raw,
         len: usize,
     ) -> Option<Self> {
-        let csound = NonNull::new(csound)?;
-        NonNull::new(ptr).map(|ptr| InputChannel {
-            csound,
-            name,
-            ptr,
-            len,
-            phantom: PhantomData,
-        })
+        unsafe { ChannelCore::new(csound, name, ptr, len) }.map(|inner| InputChannel { inner })
     }
 
     /// Returns the length of the channel buffer.
@@ -252,29 +319,39 @@ impl<'a, T: IsChannel> InputChannel<'a, T> {
     /// the current size.
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        self.inner.len()
     }
 
     /// Returns true if the channel buffer is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.inner.is_empty()
     }
 
     /// Locks the channel and returns a guard for safe access.
+    ///
+    /// This call blocks (spin-waits) until the channel lock is available.
+    ///
+    /// # Panics / Deadlock
+    /// Do not call `lock()` re-entrantly on the same channel from the same thread.
+    /// The Csound channel lock is non-recursive and will deadlock.
     #[inline]
     pub fn lock(&self) -> ChannelLock<'_, Self> {
-        ChannelLock::new(self.csound.as_ptr(), self.name.as_ptr(), self)
+        ChannelLock::new(self.inner.csound.as_ptr(), self.inner.name.as_ptr(), self)
     }
 
     /// Locks the channel, runs the closure, and releases the lock.
     ///
+    /// This call blocks (spin-waits) until the channel lock is available.
     /// This ensures the lock is held for exactly the duration of `f`,
     /// preventing references from escaping beyond the lock scope.
+    ///
+    /// # Panics / Deadlock
+    /// Do not call `with_lock()` re-entrantly on the same channel from the same thread.
+    /// The Csound channel lock is non-recursive and will deadlock.
     #[inline]
-    pub fn with_lock<R>(&self, f: impl FnOnce(&mut ChannelLock<'_, Self>) -> R) -> R {
-        let mut guard = self.lock();
-        f(&mut guard)
+    pub fn with_lock<R>(&self, f: impl FnOnce(ChannelLock<'_, Self>) -> R) -> R {
+        f(self.lock())
     }
 }
 
@@ -289,42 +366,45 @@ impl<'a, T: IsChannel> OutputChannel<'a, T> {
         ptr: *mut T::Raw,
         len: usize,
     ) -> Option<Self> {
-        let csound = NonNull::new(csound)?;
-        NonNull::new(ptr).map(|ptr| OutputChannel {
-            csound,
-            name,
-            ptr,
-            len,
-            phantom: PhantomData,
-        })
+        unsafe { ChannelCore::new(csound, name, ptr, len) }.map(|inner| OutputChannel { inner })
     }
 
     /// Returns the length of the channel buffer.
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        self.inner.len()
     }
 
     /// Returns true if the channel buffer is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.inner.is_empty()
     }
 
     /// Locks the channel and returns a guard for safe access.
+    ///
+    /// This call blocks (spin-waits) until the channel lock is available.
+    ///
+    /// # Panics / Deadlock
+    /// Do not call `lock()` re-entrantly on the same channel from the same thread.
+    /// The Csound channel lock is non-recursive and will deadlock.
     #[inline]
     pub fn lock(&self) -> ChannelLock<'_, Self> {
-        ChannelLock::new(self.csound.as_ptr(), self.name.as_ptr(), self)
+        ChannelLock::new(self.inner.csound.as_ptr(), self.inner.name.as_ptr(), self)
     }
 
     /// Locks the channel, runs the closure, and releases the lock.
     ///
+    /// This call blocks (spin-waits) until the channel lock is available.
     /// This ensures the lock is held for exactly the duration of `f`,
     /// preventing references from escaping beyond the lock scope.
+    ///
+    /// # Panics / Deadlock
+    /// Do not call `with_lock()` re-entrantly on the same channel from the same thread.
+    /// The Csound channel lock is non-recursive and will deadlock.
     #[inline]
-    pub fn with_lock<R>(&self, f: impl FnOnce(&mut ChannelLock<'_, Self>) -> R) -> R {
-        let mut guard = self.lock();
-        f(&mut guard)
+    pub fn with_lock<R>(&self, f: impl FnOnce(ChannelLock<'_, Self>) -> R) -> R {
+        f(self.lock())
     }
 }
 
@@ -369,7 +449,7 @@ impl<'a> InputChannel<'a, ControlChannel> {
     #[inline]
     pub unsafe fn get(&self) -> Myflt {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { *self.ptr.as_ptr() }
+        unsafe { *self.inner.ptr.as_ptr() }
     }
 
     /// Sets the value of the control channel.
@@ -380,7 +460,7 @@ impl<'a> InputChannel<'a, ControlChannel> {
     pub unsafe fn set(&self, value: Myflt) {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
-            *self.ptr.as_ptr() = value;
+            *self.inner.ptr.as_ptr() = value;
         }
     }
 
@@ -402,7 +482,7 @@ impl<'a> OutputChannel<'a, ControlChannel> {
     #[inline]
     pub unsafe fn get(&self) -> Myflt {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { *self.ptr.as_ptr() }
+        unsafe { *self.inner.ptr.as_ptr() }
     }
 
     /// Reads the value from the control channel (alias for `get`).
@@ -415,7 +495,7 @@ impl<'a> OutputChannel<'a, ControlChannel> {
     }
 }
 
-impl<'a> ChannelLock<'a, InputChannel<'a, ControlChannel>> {
+impl<'lock, 'chan> ChannelLock<'lock, InputChannel<'chan, ControlChannel>> {
     /// Gets the current value of the control channel.
     #[inline]
     pub fn get(&self) -> Myflt {
@@ -437,7 +517,7 @@ impl<'a> ChannelLock<'a, InputChannel<'a, ControlChannel>> {
     }
 }
 
-impl<'a> ChannelLock<'a, OutputChannel<'a, ControlChannel>> {
+impl<'lock, 'chan> ChannelLock<'lock, OutputChannel<'chan, ControlChannel>> {
     /// Gets the current value of the control channel.
     #[inline]
     pub fn get(&self) -> Myflt {
@@ -457,16 +537,6 @@ impl<'a> ChannelLock<'a, OutputChannel<'a, ControlChannel>> {
 // ============================================================================
 
 impl<'a> InputChannel<'a, AudioChannel> {
-    /// Returns an immutable slice of the audio channel's samples.
-    ///
-    /// # Safety
-    /// Caller must ensure the channel is locked or otherwise synchronized.
-    #[inline]
-    pub unsafe fn as_slice(&self) -> &[Myflt] {
-        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
-    }
-
     /// Returns a mutable slice of the audio channel's samples.
     ///
     /// # Safety
@@ -475,7 +545,7 @@ impl<'a> InputChannel<'a, AudioChannel> {
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn as_mut_slice(&self) -> &mut [Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+        unsafe { slice::from_raw_parts_mut(self.inner.ptr.as_ptr(), self.inner.len) }
     }
 
     /// Writes audio samples to the channel.
@@ -485,12 +555,13 @@ impl<'a> InputChannel<'a, AudioChannel> {
     ///
     /// # Safety
     /// Caller must ensure the channel is locked or otherwise synchronized.
-    pub unsafe fn write(&self, samples: &[Myflt]) {
-        let copy_len = samples.len().min(self.len);
+    pub unsafe fn write(&self, samples: &[Myflt]) -> usize {
+        let copy_len = samples.len().min(self.inner.len);
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
-            std::ptr::copy_nonoverlapping(samples.as_ptr(), self.ptr.as_ptr(), copy_len);
-        }
+            std::ptr::copy_nonoverlapping(samples.as_ptr(), self.inner.ptr.as_ptr(), copy_len);
+        };
+        copy_len
     }
 }
 
@@ -502,7 +573,7 @@ impl<'a> OutputChannel<'a, AudioChannel> {
     #[inline]
     pub unsafe fn as_slice(&self) -> &[Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+        unsafe { slice::from_raw_parts(self.inner.ptr.as_ptr(), self.inner.len) }
     }
 
     /// Reads the audio samples from the channel (alias for `as_slice`).
@@ -515,14 +586,7 @@ impl<'a> OutputChannel<'a, AudioChannel> {
     }
 }
 
-impl<'a> ChannelLock<'a, InputChannel<'a, AudioChannel>> {
-    /// Returns an immutable slice of the audio channel's samples.
-    #[inline]
-    pub fn as_slice(&self) -> &[Myflt] {
-        // SAFETY: channel is locked by this guard
-        unsafe { self.channel.as_slice() }
-    }
-
+impl<'lock, 'chan> ChannelLock<'lock, InputChannel<'chan, AudioChannel>> {
     /// Returns a mutable slice of the audio channel's samples.
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [Myflt] {
@@ -532,13 +596,13 @@ impl<'a> ChannelLock<'a, InputChannel<'a, AudioChannel>> {
 
     /// Writes audio samples to the channel.
     #[inline]
-    pub fn write(&mut self, samples: &[Myflt]) {
+    pub fn write(&mut self, samples: &[Myflt]) -> usize {
         // SAFETY: channel is locked by this guard
         unsafe { self.channel.write(samples) }
     }
 }
 
-impl<'a> ChannelLock<'a, OutputChannel<'a, AudioChannel>> {
+impl<'lock, 'chan> ChannelLock<'lock, OutputChannel<'chan, AudioChannel>> {
     /// Returns an immutable slice of the audio channel's samples.
     #[inline]
     pub fn as_slice(&self) -> &[Myflt] {
@@ -565,7 +629,10 @@ impl<'a> InputChannel<'a, StrChannel> {
     #[inline]
     pub unsafe fn len_bytes(&self) -> usize {
         let size = unsafe {
-            csound_sys::csoundGetChannelDatasize(self.csound.as_ptr(), self.name.as_ptr())
+            csound_sys::csoundGetChannelDatasize(
+                self.inner.csound.as_ptr(),
+                self.inner.name.as_ptr(),
+            )
         };
         if size <= 0 { 0 } else { size as usize }
     }
@@ -577,7 +644,10 @@ impl<'a> InputChannel<'a, StrChannel> {
     #[inline]
     pub unsafe fn as_slice(&self) -> &[u8] {
         let data = unsafe {
-            csound_sys::ffi_bindgen::csoundGetStringData(self.csound.as_ptr(), self.ptr.as_ptr())
+            csound_sys::ffi_bindgen::csoundGetStringData(
+                self.inner.csound.as_ptr(),
+                self.inner.ptr.as_ptr(),
+            )
         };
         if data.is_null() {
             return &[];
@@ -594,7 +664,10 @@ impl<'a> InputChannel<'a, StrChannel> {
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn as_mut_slice(&self) -> &mut [u8] {
         let data = unsafe {
-            csound_sys::ffi_bindgen::csoundGetStringData(self.csound.as_ptr(), self.ptr.as_ptr())
+            csound_sys::ffi_bindgen::csoundGetStringData(
+                self.inner.csound.as_ptr(),
+                self.inner.ptr.as_ptr(),
+            )
         };
         let size = unsafe { self.len_bytes() };
         if data.is_null() || size == 0 {
@@ -615,8 +688,8 @@ impl<'a> InputChannel<'a, StrChannel> {
         let cstr = CString::new(value)?;
         unsafe {
             csound_sys::ffi_bindgen::csoundSetStringData(
-                self.csound.as_ptr(),
-                self.ptr.as_ptr(),
+                self.inner.csound.as_ptr(),
+                self.inner.ptr.as_ptr(),
                 cstr.as_ptr(),
             );
         }
@@ -632,7 +705,10 @@ impl<'a> OutputChannel<'a, StrChannel> {
     #[inline]
     pub unsafe fn len_bytes(&self) -> usize {
         let size = unsafe {
-            csound_sys::csoundGetChannelDatasize(self.csound.as_ptr(), self.name.as_ptr())
+            csound_sys::csoundGetChannelDatasize(
+                self.inner.csound.as_ptr(),
+                self.inner.name.as_ptr(),
+            )
         };
         if size <= 0 { 0 } else { size as usize }
     }
@@ -644,7 +720,10 @@ impl<'a> OutputChannel<'a, StrChannel> {
     #[inline]
     pub unsafe fn as_slice(&self) -> &[u8] {
         let data = unsafe {
-            csound_sys::ffi_bindgen::csoundGetStringData(self.csound.as_ptr(), self.ptr.as_ptr())
+            csound_sys::ffi_bindgen::csoundGetStringData(
+                self.inner.csound.as_ptr(),
+                self.inner.ptr.as_ptr(),
+            )
         };
         if data.is_null() {
             return &[];
@@ -663,7 +742,7 @@ impl<'a> OutputChannel<'a, StrChannel> {
     }
 }
 
-impl<'a> ChannelLock<'a, InputChannel<'a, StrChannel>> {
+impl<'lock, 'chan> ChannelLock<'lock, InputChannel<'chan, StrChannel>> {
     /// Returns the current string buffer size in bytes.
     #[inline]
     pub fn len_bytes(&self) -> usize {
@@ -677,6 +756,13 @@ impl<'a> ChannelLock<'a, InputChannel<'a, StrChannel>> {
         // SAFETY: channel is locked by this guard
         let bytes = unsafe { self.channel.as_slice() };
         Ok(std::str::from_utf8(bytes)?)
+    }
+
+    /// Returns the string channel's content as raw bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.as_slice() }
     }
 
     /// Writes a Rust string to the channel, ensuring NUL termination and zeroing the remainder.
@@ -687,7 +773,7 @@ impl<'a> ChannelLock<'a, InputChannel<'a, StrChannel>> {
     }
 }
 
-impl<'a> ChannelLock<'a, OutputChannel<'a, StrChannel>> {
+impl<'lock, 'chan> ChannelLock<'lock, OutputChannel<'chan, StrChannel>> {
     /// Returns the current string buffer size in bytes.
     #[inline]
     pub fn len_bytes(&self) -> usize {
@@ -701,6 +787,13 @@ impl<'a> ChannelLock<'a, OutputChannel<'a, StrChannel>> {
         // SAFETY: channel is locked by this guard
         let bytes = unsafe { self.channel.as_slice() };
         Ok(std::str::from_utf8(bytes)?)
+    }
+
+    /// Returns the string channel's content as raw bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.as_slice() }
     }
 
     /// Reads the string channel's content as a `&str`.

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -315,8 +315,8 @@ impl<'a, T: IsChannel> InputChannel<'a, T> {
     /// Returns the length of the channel buffer.
     ///
     /// For string channels, the buffer size can change at runtime. Use
-    /// `InputChannel::<StrChannel>::len_bytes` or `as_slice().len()` to get
-    /// the current size.
+    /// `ChannelLock::len()` or `as_bytes().len()` to get the current string length,
+    /// and `capacity_bytes()` to get the buffer capacity.
     #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
@@ -622,12 +622,12 @@ impl<'lock, 'chan> ChannelLock<'lock, OutputChannel<'chan, AudioChannel>> {
 // ============================================================================
 
 impl<'a> InputChannel<'a, StrChannel> {
-    /// Returns the current string buffer size in bytes.
+    /// Returns the current string buffer capacity in bytes.
     ///
     /// # Safety
     /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub unsafe fn len_bytes(&self) -> usize {
+    pub unsafe fn capacity_bytes(&self) -> usize {
         let size = unsafe {
             csound_sys::csoundGetChannelDatasize(
                 self.inner.csound.as_ptr(),
@@ -669,7 +669,7 @@ impl<'a> InputChannel<'a, StrChannel> {
                 self.inner.ptr.as_ptr(),
             )
         };
-        let size = unsafe { self.len_bytes() };
+        let size = unsafe { self.capacity_bytes() };
         if data.is_null() || size == 0 {
             return &mut [];
         }
@@ -698,12 +698,12 @@ impl<'a> InputChannel<'a, StrChannel> {
 }
 
 impl<'a> OutputChannel<'a, StrChannel> {
-    /// Returns the current string buffer size in bytes.
+    /// Returns the current string buffer capacity in bytes.
     ///
     /// # Safety
     /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub unsafe fn len_bytes(&self) -> usize {
+    pub unsafe fn capacity_bytes(&self) -> usize {
         let size = unsafe {
             csound_sys::csoundGetChannelDatasize(
                 self.inner.csound.as_ptr(),
@@ -743,11 +743,23 @@ impl<'a> OutputChannel<'a, StrChannel> {
 }
 
 impl<'lock, 'chan> ChannelLock<'lock, InputChannel<'chan, StrChannel>> {
-    /// Returns the current string buffer size in bytes.
+    /// Returns the current string length in bytes (excluding the trailing NUL).
     #[inline]
-    pub fn len_bytes(&self) -> usize {
+    pub fn len(&self) -> usize {
+        self.as_bytes().len()
+    }
+
+    /// Returns true if the string channel is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the current string buffer capacity in bytes.
+    #[inline]
+    pub fn capacity_bytes(&self) -> usize {
         // SAFETY: channel is locked by this guard
-        unsafe { self.channel.len_bytes() }
+        unsafe { self.channel.capacity_bytes() }
     }
 
     /// Returns the string channel's content as a `&str`.
@@ -774,11 +786,23 @@ impl<'lock, 'chan> ChannelLock<'lock, InputChannel<'chan, StrChannel>> {
 }
 
 impl<'lock, 'chan> ChannelLock<'lock, OutputChannel<'chan, StrChannel>> {
-    /// Returns the current string buffer size in bytes.
+    /// Returns the current string length in bytes (excluding the trailing NUL).
     #[inline]
-    pub fn len_bytes(&self) -> usize {
+    pub fn len(&self) -> usize {
+        self.as_bytes().len()
+    }
+
+    /// Returns true if the string channel is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the current string buffer capacity in bytes.
+    #[inline]
+    pub fn capacity_bytes(&self) -> usize {
         // SAFETY: channel is locked by this guard
-        unsafe { self.channel.len_bytes() }
+        unsafe { self.channel.capacity_bytes() }
     }
 
     /// Returns the string channel's content as a `&str`.

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,11 +1,18 @@
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::slice;
 
+use csound_sys::ffi_bindgen::STRINGDAT;
+use libc::c_char;
+
 use crate::Myflt;
 use crate::enums::{AudioChannel, ControlChannel, ControlChannelType, StrChannel};
-use crate::error::{Error, Result};
+use crate::error::Result;
+
+mod sealed {
+    pub trait Sealed {}
+}
 
 /// Indicates the channel behavior.
 // Unknown(u32) preserves unrecognized values from the C API, keeping
@@ -160,8 +167,10 @@ impl PvsDataExt {
 /// Use the explicit `get()`, `set()`, `write()`, and slice accessor methods
 /// rather than relying on implicit dereferencing.
 #[derive(Debug)]
-pub struct InputChannel<'a, T> {
-    ptr: NonNull<Myflt>,
+pub struct InputChannel<'a, T: IsChannel> {
+    csound: NonNull<csound_sys::CSOUND>,
+    name: CString,
+    ptr: NonNull<T::Raw>,
     len: usize,
     phantom: PhantomData<&'a mut T>,
 }
@@ -172,24 +181,64 @@ pub struct InputChannel<'a, T> {
 /// Use the explicit `get()`, `read()`, and slice accessor methods
 /// rather than relying on implicit dereferencing.
 #[derive(Debug)]
-pub struct OutputChannel<'a, T> {
-    ptr: NonNull<Myflt>,
+pub struct OutputChannel<'a, T: IsChannel> {
+    csound: NonNull<csound_sys::CSOUND>,
+    name: CString,
+    ptr: NonNull<T::Raw>,
     len: usize,
     phantom: PhantomData<&'a T>,
 }
 
+/// Guard that locks a channel for safe pointer access.
+#[must_use = "ChannelLock unlocks on drop; keep it alive for the duration of channel access"]
+#[derive(Debug)]
+pub struct ChannelLock<'a, C> {
+    csound: *mut csound_sys::CSOUND,
+    name: *const c_char,
+    channel: &'a C,
+}
+
+impl<'a, C> ChannelLock<'a, C> {
+    fn new(csound: *mut csound_sys::CSOUND, name: *const c_char, channel: &'a C) -> Self {
+        unsafe {
+            csound_sys::csoundLockChannel(csound, name);
+        }
+        ChannelLock {
+            csound,
+            name,
+            channel,
+        }
+    }
+}
+
+impl<C> Drop for ChannelLock<'_, C> {
+    fn drop(&mut self) {
+        unsafe {
+            csound_sys::csoundUnlockChannel(self.csound, self.name);
+        }
+    }
+}
+
 // SAFETY: Channel pointers are tied to the Csound instance lifetime
 // and access is synchronized through csound's own mechanisms.
-unsafe impl<T> Send for InputChannel<'_, T> {}
-unsafe impl<T> Send for OutputChannel<'_, T> {}
+unsafe impl<T: IsChannel> Send for InputChannel<'_, T> {}
+unsafe impl<T: IsChannel> Send for OutputChannel<'_, T> {}
 
-impl<'a, T> InputChannel<'a, T> {
+impl<'a, T: IsChannel> InputChannel<'a, T> {
     /// Creates a new InputChannel from a raw pointer.
     ///
     /// # Safety
     /// The pointer must be valid and point to memory owned by csound.
-    pub(crate) unsafe fn from_raw(ptr: *mut Myflt, len: usize) -> Option<Self> {
+    pub(crate) unsafe fn from_raw(
+        csound: *mut csound_sys::CSOUND,
+        name: CString,
+        ptr: *mut T::Raw,
+        len: usize,
+    ) -> Option<Self> {
+        let csound = NonNull::new(csound)?;
         NonNull::new(ptr).map(|ptr| InputChannel {
+            csound,
+            name,
             ptr,
             len,
             phantom: PhantomData,
@@ -197,6 +246,10 @@ impl<'a, T> InputChannel<'a, T> {
     }
 
     /// Returns the length of the channel buffer.
+    ///
+    /// For string channels, the buffer size can change at runtime. Use
+    /// `InputChannel::<StrChannel>::len_bytes` or `as_slice().len()` to get
+    /// the current size.
     #[inline]
     pub fn len(&self) -> usize {
         self.len
@@ -207,15 +260,39 @@ impl<'a, T> InputChannel<'a, T> {
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
+
+    /// Locks the channel and returns a guard for safe access.
+    #[inline]
+    pub fn lock(&self) -> ChannelLock<'_, Self> {
+        ChannelLock::new(self.csound.as_ptr(), self.name.as_ptr(), self)
+    }
+
+    /// Locks the channel, runs the closure, and releases the lock.
+    ///
+    /// This ensures the lock is held for exactly the duration of `f`,
+    /// preventing references from escaping beyond the lock scope.
+    #[inline]
+    pub fn with_lock<R>(&self, f: impl FnOnce(&mut ChannelLock<'_, Self>) -> R) -> R {
+        let mut guard = self.lock();
+        f(&mut guard)
+    }
 }
 
-impl<'a, T> OutputChannel<'a, T> {
+impl<'a, T: IsChannel> OutputChannel<'a, T> {
     /// Creates a new OutputChannel from a raw pointer.
     ///
     /// # Safety
     /// The pointer must be valid and point to memory owned by csound.
-    pub(crate) unsafe fn from_raw(ptr: *mut Myflt, len: usize) -> Option<Self> {
+    pub(crate) unsafe fn from_raw(
+        csound: *mut csound_sys::CSOUND,
+        name: CString,
+        ptr: *mut T::Raw,
+        len: usize,
+    ) -> Option<Self> {
+        let csound = NonNull::new(csound)?;
         NonNull::new(ptr).map(|ptr| OutputChannel {
+            csound,
+            name,
             ptr,
             len,
             phantom: PhantomData,
@@ -233,25 +310,48 @@ impl<'a, T> OutputChannel<'a, T> {
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
+
+    /// Locks the channel and returns a guard for safe access.
+    #[inline]
+    pub fn lock(&self) -> ChannelLock<'_, Self> {
+        ChannelLock::new(self.csound.as_ptr(), self.name.as_ptr(), self)
+    }
+
+    /// Locks the channel, runs the closure, and releases the lock.
+    ///
+    /// This ensures the lock is held for exactly the duration of `f`,
+    /// preventing references from escaping beyond the lock scope.
+    #[inline]
+    pub fn with_lock<R>(&self, f: impl FnOnce(&mut ChannelLock<'_, Self>) -> R) -> R {
+        let mut guard = self.lock();
+        f(&mut guard)
+    }
 }
 
-pub trait IsChannel {
+pub trait IsChannel: sealed::Sealed {
+    type Raw;
     fn c_type() -> ControlChannelType;
 }
 
+impl sealed::Sealed for ControlChannel {}
 impl IsChannel for ControlChannel {
+    type Raw = Myflt;
     fn c_type() -> ControlChannelType {
         ControlChannelType::Control
     }
 }
 
+impl sealed::Sealed for AudioChannel {}
 impl IsChannel for AudioChannel {
+    type Raw = Myflt;
     fn c_type() -> ControlChannelType {
         ControlChannelType::Audio
     }
 }
 
+impl sealed::Sealed for StrChannel {}
 impl IsChannel for StrChannel {
+    type Raw = STRINGDAT;
     fn c_type() -> ControlChannelType {
         ControlChannelType::String
     }
@@ -263,15 +363,21 @@ impl IsChannel for StrChannel {
 
 impl<'a> InputChannel<'a, ControlChannel> {
     /// Gets the current value of the control channel.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub fn get(&self) -> Myflt {
+    pub unsafe fn get(&self) -> Myflt {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { *self.ptr.as_ptr() }
     }
 
     /// Sets the value of the control channel.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub fn set(&self, value: Myflt) {
+    pub unsafe fn set(&self, value: Myflt) {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
             *self.ptr.as_ptr() = value;
@@ -279,18 +385,64 @@ impl<'a> InputChannel<'a, ControlChannel> {
     }
 
     /// Writes a value to the control channel (alias for `set`).
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub fn write(&self, value: Myflt) {
-        self.set(value);
+    pub unsafe fn write(&self, value: Myflt) {
+        unsafe { self.set(value) };
     }
 }
 
 impl<'a> OutputChannel<'a, ControlChannel> {
     /// Gets the current value of the control channel.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub fn get(&self) -> Myflt {
+    pub unsafe fn get(&self) -> Myflt {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { *self.ptr.as_ptr() }
+    }
+
+    /// Reads the value from the control channel (alias for `get`).
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    #[inline]
+    pub unsafe fn read(&self) -> Myflt {
+        unsafe { self.get() }
+    }
+}
+
+impl<'a> ChannelLock<'a, InputChannel<'a, ControlChannel>> {
+    /// Gets the current value of the control channel.
+    #[inline]
+    pub fn get(&self) -> Myflt {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.get() }
+    }
+
+    /// Sets the value of the control channel.
+    #[inline]
+    pub fn set(&mut self, value: Myflt) {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.set(value) }
+    }
+
+    /// Writes a value to the control channel (alias for `set`).
+    #[inline]
+    pub fn write(&mut self, value: Myflt) {
+        self.set(value);
+    }
+}
+
+impl<'a> ChannelLock<'a, OutputChannel<'a, ControlChannel>> {
+    /// Gets the current value of the control channel.
+    #[inline]
+    pub fn get(&self) -> Myflt {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.get() }
     }
 
     /// Reads the value from the control channel (alias for `get`).
@@ -306,8 +458,11 @@ impl<'a> OutputChannel<'a, ControlChannel> {
 
 impl<'a> InputChannel<'a, AudioChannel> {
     /// Returns an immutable slice of the audio channel's samples.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub fn as_slice(&self) -> &[Myflt] {
+    pub unsafe fn as_slice(&self) -> &[Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
     }
@@ -315,9 +470,10 @@ impl<'a> InputChannel<'a, AudioChannel> {
     /// Returns a mutable slice of the audio channel's samples.
     ///
     /// # Safety
-    /// Caller must ensure no aliasing occurs with csound's internal access.
+    /// Caller must ensure the channel is locked and no aliasing occurs with csound's internal access.
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [Myflt] {
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn as_mut_slice(&self) -> &mut [Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
@@ -326,7 +482,10 @@ impl<'a> InputChannel<'a, AudioChannel> {
     ///
     /// If the input slice is longer than the channel buffer,
     /// only `len()` samples will be copied.
-    pub fn write(&self, samples: &[Myflt]) {
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    pub unsafe fn write(&self, samples: &[Myflt]) {
         let copy_len = samples.len().min(self.len);
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
@@ -337,10 +496,54 @@ impl<'a> InputChannel<'a, AudioChannel> {
 
 impl<'a> OutputChannel<'a, AudioChannel> {
     /// Returns an immutable slice of the audio channel's samples.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub fn as_slice(&self) -> &[Myflt] {
+    pub unsafe fn as_slice(&self) -> &[Myflt] {
         // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Reads the audio samples from the channel (alias for `as_slice`).
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    #[inline]
+    pub unsafe fn read(&self) -> &[Myflt] {
+        unsafe { self.as_slice() }
+    }
+}
+
+impl<'a> ChannelLock<'a, InputChannel<'a, AudioChannel>> {
+    /// Returns an immutable slice of the audio channel's samples.
+    #[inline]
+    pub fn as_slice(&self) -> &[Myflt] {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.as_slice() }
+    }
+
+    /// Returns a mutable slice of the audio channel's samples.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [Myflt] {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.as_mut_slice() }
+    }
+
+    /// Writes audio samples to the channel.
+    #[inline]
+    pub fn write(&mut self, samples: &[Myflt]) {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.write(samples) }
+    }
+}
+
+impl<'a> ChannelLock<'a, OutputChannel<'a, AudioChannel>> {
+    /// Returns an immutable slice of the audio channel's samples.
+    #[inline]
+    pub fn as_slice(&self) -> &[Myflt] {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.as_slice() }
     }
 
     /// Reads the audio samples from the channel (alias for `as_slice`).
@@ -355,56 +558,147 @@ impl<'a> OutputChannel<'a, AudioChannel> {
 // ============================================================================
 
 impl<'a> InputChannel<'a, StrChannel> {
-    /// Returns an immutable slice of the string channel's bytes.
+    /// Returns the current string buffer size in bytes.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
     #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { slice::from_raw_parts(self.ptr.as_ptr() as *const u8, self.len) }
+    pub unsafe fn len_bytes(&self) -> usize {
+        let size = unsafe {
+            csound_sys::csoundGetChannelDatasize(self.csound.as_ptr(), self.name.as_ptr())
+        };
+        if size <= 0 { 0 } else { size as usize }
+    }
+
+    /// Returns an immutable slice of the string channel's bytes.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    #[inline]
+    pub unsafe fn as_slice(&self) -> &[u8] {
+        let data = unsafe {
+            csound_sys::ffi_bindgen::csoundGetStringData(self.csound.as_ptr(), self.ptr.as_ptr())
+        };
+        if data.is_null() {
+            return &[];
+        }
+        // SAFETY: pointer is a valid NUL-terminated string
+        unsafe { CStr::from_ptr(data).to_bytes() }
     }
 
     /// Returns a mutable slice of the string channel's bytes.
     ///
     /// # Safety
-    /// Caller must ensure no aliasing occurs with csound's internal access.
+    /// Caller must ensure the channel is locked and no aliasing occurs with csound's internal access.
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr() as *mut u8, self.len) }
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn as_mut_slice(&self) -> &mut [u8] {
+        let data = unsafe {
+            csound_sys::ffi_bindgen::csoundGetStringData(self.csound.as_ptr(), self.ptr.as_ptr())
+        };
+        let size = unsafe { self.len_bytes() };
+        if data.is_null() || size == 0 {
+            return &mut [];
+        }
+        // SAFETY: caller guarantees exclusive access and size bytes are valid
+        unsafe { slice::from_raw_parts_mut(data as *mut u8, size) }
     }
 
     /// Writes a Rust string to the channel, ensuring NUL termination and zeroing the remainder.
     ///
     /// # Errors
     /// - [`Error::Nul`] if the string contains an interior NUL byte
-    /// - [`Error::InsufficientCapacity`] if the channel buffer is too small
-    pub fn write_str(&self, value: &str) -> Result<()> {
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    pub unsafe fn write_str(&self, value: &str) -> Result<()> {
         let cstr = CString::new(value)?;
-        let bytes = cstr.as_bytes_with_nul();
-        if bytes.len() > self.len {
-            return Err(Error::InsufficientCapacity {
-                expected: bytes.len(),
-                actual: self.len,
-            });
-        }
-
-        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
         unsafe {
-            let dst = self.ptr.as_ptr() as *mut u8;
-            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, bytes.len());
-            if self.len > bytes.len() {
-                std::ptr::write_bytes(dst.add(bytes.len()), 0, self.len - bytes.len());
-            }
+            csound_sys::ffi_bindgen::csoundSetStringData(
+                self.csound.as_ptr(),
+                self.ptr.as_ptr(),
+                cstr.as_ptr(),
+            );
         }
         Ok(())
     }
 }
 
 impl<'a> OutputChannel<'a, StrChannel> {
+    /// Returns the current string buffer size in bytes.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    #[inline]
+    pub unsafe fn len_bytes(&self) -> usize {
+        let size = unsafe {
+            csound_sys::csoundGetChannelDatasize(self.csound.as_ptr(), self.name.as_ptr())
+        };
+        if size <= 0 { 0 } else { size as usize }
+    }
+
+    /// Returns an immutable slice of the string channel's bytes.
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    #[inline]
+    pub unsafe fn as_slice(&self) -> &[u8] {
+        let data = unsafe {
+            csound_sys::ffi_bindgen::csoundGetStringData(self.csound.as_ptr(), self.ptr.as_ptr())
+        };
+        if data.is_null() {
+            return &[];
+        }
+        // SAFETY: pointer is a valid NUL-terminated string
+        unsafe { CStr::from_ptr(data).to_bytes() }
+    }
+
+    /// Reads the string channel's bytes (alias for `as_slice`).
+    ///
+    /// # Safety
+    /// Caller must ensure the channel is locked or otherwise synchronized.
+    #[inline]
+    pub unsafe fn read(&self) -> &[u8] {
+        unsafe { self.as_slice() }
+    }
+}
+
+impl<'a> ChannelLock<'a, InputChannel<'a, StrChannel>> {
+    /// Returns the current string buffer size in bytes.
+    #[inline]
+    pub fn len_bytes(&self) -> usize {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.len_bytes() }
+    }
+
     /// Returns an immutable slice of the string channel's bytes.
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        // SAFETY: pointer is guaranteed non-null and valid for the channel lifetime
-        unsafe { slice::from_raw_parts(self.ptr.as_ptr() as *const u8, self.len) }
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.as_slice() }
+    }
+
+    /// Writes a Rust string to the channel, ensuring NUL termination and zeroing the remainder.
+    #[inline]
+    pub fn write_str(&mut self, value: &str) -> Result<()> {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.write_str(value) }
+    }
+}
+
+impl<'a> ChannelLock<'a, OutputChannel<'a, StrChannel>> {
+    /// Returns the current string buffer size in bytes.
+    #[inline]
+    pub fn len_bytes(&self) -> usize {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.len_bytes() }
+    }
+
+    /// Returns an immutable slice of the string channel's bytes.
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: channel is locked by this guard
+        unsafe { self.channel.as_slice() }
     }
 
     /// Reads the string channel's bytes (alias for `as_slice`).

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -71,7 +71,7 @@ pub(crate) struct Inner {
 }
 
 /// Global initialization guard - csound is initialized exactly once
-static CSOUND_INIT: OnceLock<()> = OnceLock::new();
+static CSOUND_INIT: OnceLock<i32> = OnceLock::new();
 
 // SAFETY: The CSOUND pointer can be safely sent between threads when:
 // 1. Access is externally synchronized (e.g., via Mutex), OR
@@ -108,13 +108,17 @@ impl Csound {
     /// ```
     pub fn new() -> Result<Self> {
         // Initialize csound library exactly once (thread-safe)
-        CSOUND_INIT.get_or_init(|| {
-            let flags = (csound_sys::CSOUNDINIT_NO_SIGNAL_HANDLER
-                | csound_sys::CSOUNDINIT_NO_ATEXIT) as c_int;
-            unsafe {
-                csound_sys::csoundInitialize(flags);
-            }
-        });
+        let flags =
+            (csound_sys::CSOUNDINIT_NO_SIGNAL_HANDLER | csound_sys::CSOUNDINIT_NO_ATEXIT) as c_int;
+        let status = *CSOUND_INIT.get_or_init(|| unsafe { csound_sys::csoundInitialize(flags) });
+        match Status::from(status) {
+            Status::Success => {}
+            Status::Signal => return Err(Error::Signal),
+            Status::Memory => return Err(Error::Memory),
+            Status::Performance => return Err(Error::Performance),
+            Status::Initialization => return Err(Error::Initialization),
+            _ => return Err(Error::InitFailed),
+        }
 
         // Ensure MYFLT size matches the linked Csound library.
         let expected = std::mem::size_of::<crate::Myflt>();
@@ -222,7 +226,7 @@ impl Csound {
 
     /// Returns the raw csound pointer for FFI calls.
     #[inline]
-    fn csound_ptr(&self) -> *mut csound_sys::CSOUND {
+    pub(crate) fn csound_ptr(&self) -> *mut csound_sys::CSOUND {
         self.engine.csound.as_ptr()
     }
 
@@ -246,12 +250,17 @@ impl Csound {
     /// ```
     ///
     pub fn start(&self) -> Result<()> {
-        unsafe {
-            if csound_sys::csoundStart(self.csound_ptr()) == CSOUND_STATUS::CSOUND_SUCCESS {
-                Ok(())
-            } else {
-                tracing::error!("csound already started, call reset() before starting again");
-                Err(Error::AlreadyStarted)
+        let status = unsafe { csound_sys::csoundStart(self.csound_ptr()) };
+        match Status::from(status) {
+            Status::Success => Ok(()),
+            Status::Signal => Err(Error::Signal),
+            Status::Memory => Err(Error::Memory),
+            Status::Performance => Err(Error::Performance),
+            Status::Initialization => Err(Error::Initialization),
+            Status::Error => Err(Error::AlreadyStarted),
+            Status::Ok(x) => {
+                tracing::error!("csoundStart failed with code {x}");
+                Err(Error::OperationFailed)
             }
         }
     }
@@ -1206,12 +1215,15 @@ impl Csound {
     /// // Request a csound's input control channel
     /// let control_channel = csound.get_input_channel::<ControlChannel>("myChannel").unwrap();
     /// // Writes some data to the channel
-    /// println!("channel value {}", control_channel.read());
+    /// control_channel.lock().write(0.5);
     /// // Request a csound's input audio channel
-    /// let audio_channel = csound.get_input_channel::<AudioChannle>("myAudioChannel").unwrap();
-    /// println!("audio channel samples {:?}", audio_channel.read() );
+    /// let audio_channel = csound.get_input_channel::<AudioChannel>("myAudioChannel").unwrap();
+    /// let mut audio_guard = audio_channel.lock();
+    /// println!("audio channel samples {:?}", audio_guard.as_slice());
     /// // Request a csound's input string channel
     /// let string_channel = csound.get_input_channel::<StrChannel>("myStringChannel").unwrap();
+    /// let mut string_guard = string_channel.lock();
+    /// string_guard.write_str("hello").unwrap();
     ///
     /// ```
     ///
@@ -1224,8 +1236,8 @@ impl Csound {
     where
         T: IsChannel,
     {
-        let mut ptr = ptr::null_mut();
-        let ptr = &mut ptr as *mut *mut _;
+        let mut ptr: *mut c_void = ptr::null_mut();
+        let ptr_ref = &mut ptr as *mut *mut c_void;
         let len;
         let bits;
 
@@ -1241,7 +1253,9 @@ impl Csound {
                     | controlChannelType::CSOUND_INPUT_CHANNEL) as c_int;
             }
             ControlChannelType::String => {
-                len = self.get_channel_data_size(name)?;
+                // Defer datasize lookup until after csoundGetChannelPtr,
+                // so string channels can be created if missing.
+                len = 0;
                 bits = (controlChannelType::CSOUND_STRING_CHANNEL
                     | controlChannelType::CSOUND_INPUT_CHANNEL) as c_int;
             }
@@ -1253,12 +1267,20 @@ impl Csound {
             }
         }
 
-        let status = self.get_raw_channel_ptr(name, ptr, bits);
+        let cname = CString::new(name)?;
+        let status = self.get_raw_channel_ptr(&cname, ptr_ref, bits);
         match Status::from(status) {
-            Status::Success => unsafe {
-                InputChannel::from_raw(*ptr, len)
-                    .ok_or(Error::NullPointer("failed to create input channel"))
-            },
+            Status::Success => {
+                let len = if matches!(T::c_type(), ControlChannelType::String) {
+                    self.get_channel_data_size(name)?
+                } else {
+                    len
+                };
+                unsafe {
+                    InputChannel::from_raw(self.csound_ptr(), cname, ptr as *mut T::Raw, len)
+                        .ok_or(Error::NullPointer("failed to create input channel"))
+                }
+            }
             Status::Memory => {
                 tracing::error!(channel = name, "memory allocation failed for input channel");
                 Err(Error::Memory)
@@ -1325,13 +1347,16 @@ impl Csound {
     /// csound.start();
     /// // Request a csound's output control channel
     /// let control_channel = csound.get_output_channel::<ControlChannel>("myChannel").unwrap();
-    /// // Writes some data to the channel
-    /// println!("channel value {}", control_channel.read());
+    /// // Reads data from the channel
+    /// println!("channel value {}", control_channel.lock().read());
     /// // Request a csound's output audio channel
-    /// let audio_channel = csound.get_output_channel::<AudioChannle>("myAudioChannel").unwrap();
-    /// println!("audio channel samples {:?}", audio_channel.read() );
+    /// let audio_channel = csound.get_output_channel::<AudioChannel>("myAudioChannel").unwrap();
+    /// let audio_guard = audio_channel.lock();
+    /// println!("audio channel samples {:?}", audio_guard.as_slice());
     /// // Request a csound's output string channel
     /// let string_channel = csound.get_output_channel::<StrChannel>("myStringChannel").unwrap();
+    /// let string_guard = string_channel.lock();
+    /// println!("string bytes {:?}", string_guard.as_slice());
     ///
     /// ```
     ///
@@ -1344,8 +1369,8 @@ impl Csound {
     where
         T: IsChannel,
     {
-        let mut ptr = ptr::null_mut();
-        let ptr = &mut ptr as *mut *mut _;
+        let mut ptr: *mut c_void = ptr::null_mut();
+        let ptr_ref = &mut ptr as *mut *mut c_void;
 
         let len;
         let bits;
@@ -1362,7 +1387,9 @@ impl Csound {
                     | controlChannelType::CSOUND_OUTPUT_CHANNEL) as c_int;
             }
             ControlChannelType::String => {
-                len = self.get_channel_data_size(name)?;
+                // Defer datasize lookup until after csoundGetChannelPtr,
+                // so string channels can be created if missing.
+                len = 0;
                 bits = (controlChannelType::CSOUND_STRING_CHANNEL
                     | controlChannelType::CSOUND_OUTPUT_CHANNEL) as c_int;
             }
@@ -1374,12 +1401,20 @@ impl Csound {
             }
         }
 
-        let status = self.get_raw_channel_ptr(name, ptr, bits);
+        let cname = CString::new(name)?;
+        let status = self.get_raw_channel_ptr(&cname, ptr_ref, bits);
         match Status::from(status) {
-            Status::Success => unsafe {
-                OutputChannel::from_raw(*ptr, len)
-                    .ok_or(Error::NullPointer("failed to create output channel"))
-            },
+            Status::Success => {
+                let len = if matches!(T::c_type(), ControlChannelType::String) {
+                    self.get_channel_data_size(name)?
+                } else {
+                    len
+                };
+                unsafe {
+                    OutputChannel::from_raw(self.csound_ptr(), cname, ptr as *mut T::Raw, len)
+                        .ok_or(Error::NullPointer("failed to create output channel"))
+                }
+            }
             Status::Memory => {
                 tracing::error!(
                     channel = name,
@@ -1405,21 +1440,12 @@ impl Csound {
 
     pub(crate) fn get_raw_channel_ptr(
         &self,
-        name: &str,
-        ptr: *mut *mut Myflt,
+        cname: &CString,
+        ptr: *mut *mut c_void,
         channel_type: c_int,
     ) -> c_int {
-        let cname = match CString::new(name) {
-            Ok(c) => c,
-            Err(_) => return -1,
-        };
         unsafe {
-            csound_sys::csoundGetChannelPtr(
-                self.csound_ptr(),
-                ptr as *mut *mut c_void,
-                cname.as_ptr(),
-                channel_type,
-            )
+            csound_sys::csoundGetChannelPtr(self.csound_ptr(), ptr, cname.as_ptr(), channel_type)
         }
     }
 
@@ -1499,7 +1525,11 @@ impl Csound {
                 let attributes = if hint.attributes.is_null() {
                     None
                 } else {
-                    Some(Trampoline::ptr_to_string(hint.attributes)?)
+                    let result = Trampoline::ptr_to_string(hint.attributes);
+                    // csoundGetControlChannelHints allocates attributes with csound's allocator.
+                    // We free it here to avoid leaking per call.
+                    unsafe { libc::free(hint.attributes as *mut c_void) };
+                    Some(result?)
                 };
                 Ok(ChannelHints {
                     behav: ChannelBehavior::from(hint.behav),

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1587,7 +1587,10 @@ impl Csound {
     /// Sets the value of a control channel.
     /// # Arguments
     /// * `name`  The channel name.
-    pub fn set_control_channel(&mut self, name: &str, value: Myflt) -> Result<()> {
+    ///
+    /// This function is thread-safe and can be called concurrently with
+    /// [`Csound::perform_ksmps`](struct.Csound.html#method.perform_ksmps).
+    pub fn set_control_channel(&self, name: &str, value: Myflt) -> Result<()> {
         let cname = CString::new(name)?;
         unsafe { csound_sys::csoundSetControlChannel(self.csound_ptr(), cname.as_ptr(), value) };
         Ok(())

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1356,7 +1356,7 @@ impl Csound {
     /// // Request a csound's output string channel
     /// let string_channel = csound.get_output_channel::<StrChannel>("myStringChannel").unwrap();
     /// let string_guard = string_channel.lock();
-    /// println!("string bytes {:?}", string_guard.as_slice());
+    /// println!("string value {:?}", string_guard.as_str());
     ///
     /// ```
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,9 @@ mod table;
 
 pub use crate::csound::{BufferPtr, CircularBuffer, Csound, OpcodeListEntry};
 pub use callbacks::{FileInfo, PanicState, PanickedCallbacks};
-pub use channels::{ChannelHints, ChannelInfo, InputChannel, OutputChannel, PvsDataExt};
+pub use channels::{
+    ChannelHints, ChannelInfo, ChannelLock, InputChannel, OutputChannel, PvsDataExt,
+};
 pub use enums::{
     AudioChannel, ChannelData, ControlChannel, FileTypes, Language, MessageType, ScoreEventType,
     Status, StrChannel,

--- a/tests/channel_lock_threaded.rs
+++ b/tests/channel_lock_threaded.rs
@@ -1,0 +1,212 @@
+//! Integration test for threaded channel access with ChannelLock.
+//!
+//! Verifies that InputChannel and OutputChannel can be moved into
+//! separate threads and that ChannelLock provides correct synchronized
+//! access to control channel pointers while Csound runs perform_ksmps
+//! on another thread.
+
+use csound::{ControlChannel, Csound, InputChannel, MessageType, OutputChannel};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+static ORC: &str = r#"
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs = 1
+
+chn_k "gain", 1
+chn_k "meter", 2
+
+instr 1
+  k_gain chnget "gain"
+  k_meter = k_gain * 2
+  chnset k_meter, "meter"
+endin
+"#;
+
+struct SendCsound(std::ptr::NonNull<Csound>);
+
+// SAFETY: The pointer targets a leaked Csound instance that outlives
+// all threads.  perform_ksmps() is called only from one thread;
+// channel access on other threads is synchronized via ChannelLock.
+unsafe impl Send for SendCsound {}
+
+impl SendCsound {
+    fn from_ref(cs: &'static Csound) -> Self {
+        SendCsound(std::ptr::NonNull::from(cs))
+    }
+
+    fn csound(&self) -> &Csound {
+        // SAFETY: pointer is valid for the lifetime of the process
+        unsafe { self.0.as_ref() }
+    }
+}
+
+fn create_test_csound() -> Csound {
+    let cs = Csound::new().expect("Failed to create Csound instance");
+    cs.set_option("-n").expect("Failed to set -n option");
+    cs.set_option("-d").expect("Failed to set -d option");
+    cs.set_option("-m0").expect("Failed to set -m0 option");
+    cs.message_string_callback(|_: MessageType, _: &str| {});
+    cs
+}
+
+#[test]
+fn test_threaded_control_channel_lock_roundtrip() {
+    let cs: &'static Csound = Box::leak(Box::new(create_test_csound()));
+
+    cs.compile_orc(ORC, 0).expect("Failed to compile orchestra");
+    cs.start().expect("Failed to start Csound");
+    cs.send_string_event("i1 0 10", 0)
+        .expect("Failed to start instrument");
+
+    let gain_in: InputChannel<'static, ControlChannel> = cs
+        .get_input_channel::<ControlChannel>("gain")
+        .expect("Failed to get input channel 'gain'");
+
+    let meter_out: OutputChannel<'static, ControlChannel> = cs
+        .get_output_channel::<ControlChannel>("meter")
+        .expect("Failed to get output channel 'meter'");
+
+    let running = Arc::new(AtomicBool::new(true));
+
+    let perf_cs = SendCsound::from_ref(cs);
+    let perf_running = Arc::clone(&running);
+    let perf = thread::spawn(move || {
+        while perf_running.load(Ordering::SeqCst) {
+            if perf_cs.csound().perform_ksmps() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+    });
+
+    let writer = thread::spawn(move || {
+        for i in 0..50 {
+            let value = i as f64 / 50.0;
+            gain_in.with_lock(move |mut guard| guard.set(value));
+            thread::sleep(Duration::from_millis(5));
+        }
+    });
+
+    let reader = thread::spawn(move || {
+        let mut seen_nonzero = false;
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(2) {
+            let value = meter_out.with_lock(|g| g.read());
+            if value.abs() > 1e-6 {
+                seen_nonzero = true;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        seen_nonzero
+    });
+
+    writer.join().expect("writer thread panicked");
+    let seen_nonzero = reader.join().expect("reader thread panicked");
+    running.store(false, Ordering::SeqCst);
+    perf.join().expect("performance thread panicked");
+
+    assert!(
+        seen_nonzero,
+        "Reader should have observed a non-zero meter value via ChannelLock"
+    );
+}
+
+#[test]
+fn test_channel_lock_write_read_consistency() {
+    let cs: &'static Csound = Box::leak(Box::new(create_test_csound()));
+
+    cs.compile_orc(ORC, 0).expect("Failed to compile orchestra");
+    cs.start().expect("Failed to start Csound");
+    cs.send_string_event("i1 0 10", 0)
+        .expect("Failed to start instrument");
+
+    let gain_in: InputChannel<'static, ControlChannel> = cs
+        .get_input_channel::<ControlChannel>("gain")
+        .expect("Failed to get input channel 'gain'");
+
+    let meter_out: OutputChannel<'static, ControlChannel> = cs
+        .get_output_channel::<ControlChannel>("meter")
+        .expect("Failed to get output channel 'meter'");
+
+    let running = Arc::new(AtomicBool::new(true));
+
+    let perf_cs = SendCsound::from_ref(cs);
+    let perf_running = Arc::clone(&running);
+    let perf = thread::spawn(move || {
+        while perf_running.load(Ordering::SeqCst) {
+            if perf_cs.csound().perform_ksmps() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+    });
+
+    // Write a known value and give Csound time to process
+    {
+        let mut guard = gain_in.lock();
+        guard.set(0.25);
+    }
+    thread::sleep(Duration::from_millis(100));
+
+    // The orchestra doubles gain -> meter, so meter should be ~0.5
+    let meter = meter_out.with_lock(|g| g.read());
+
+    running.store(false, Ordering::SeqCst);
+    perf.join().expect("performance thread panicked");
+
+    assert!(
+        (meter - 0.5).abs() < 0.01,
+        "meter should be 2 * gain (0.5), got {meter}"
+    );
+}
+
+#[test]
+fn test_channel_lock_write_read_consistency_unsafe() {
+    let cs: &'static Csound = Box::leak(Box::new(create_test_csound()));
+
+    cs.compile_orc(ORC, 0).expect("Failed to compile orchestra");
+    cs.start().expect("Failed to start Csound");
+    cs.send_string_event("i1 0 10", 0)
+        .expect("Failed to start instrument");
+
+    let gain_in: InputChannel<'static, ControlChannel> = cs
+        .get_input_channel::<ControlChannel>("gain")
+        .expect("Failed to get input channel 'gain'");
+
+    let meter_out: OutputChannel<'static, ControlChannel> = cs
+        .get_output_channel::<ControlChannel>("meter")
+        .expect("Failed to get output channel 'meter'");
+
+    let running = Arc::new(AtomicBool::new(true));
+
+    let perf_cs = SendCsound::from_ref(cs);
+    let perf_running = Arc::clone(&running);
+    let perf = thread::spawn(move || {
+        while perf_running.load(Ordering::SeqCst) {
+            if perf_cs.csound().perform_ksmps() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+    });
+
+    // Write using the unsafe set (no lock)
+    unsafe { gain_in.set(0.25) };
+    thread::sleep(Duration::from_millis(100));
+
+    // Read using the unsafe read (no lock)
+    let meter = unsafe { meter_out.read() };
+
+    running.store(false, Ordering::SeqCst);
+    perf.join().expect("performance thread panicked");
+
+    assert!(
+        (meter - 0.5).abs() < 0.01,
+        "meter should be 2 * gain (0.5), got {meter}"
+    );
+}

--- a/tests/channel_table_message_tests.rs
+++ b/tests/channel_table_message_tests.rs
@@ -44,7 +44,7 @@ endin
 
 #[test]
 fn test_control_channel_roundtrip() {
-    let mut cs = create_test_csound();
+    let cs = create_test_csound();
 
     cs.compile_orc(CONTROL_CHANNEL_ORC, 0)
         .expect("Failed to compile orchestra");
@@ -68,7 +68,7 @@ fn test_control_channel_roundtrip() {
 
 #[test]
 fn test_control_channel_multiple_values() {
-    let mut cs = create_test_csound();
+    let cs = create_test_csound();
 
     cs.compile_orc(CONTROL_CHANNEL_ORC, 0)
         .expect("Failed to compile orchestra");
@@ -603,7 +603,7 @@ fn test_message_buffer_attributes() {
 
 #[test]
 fn test_list_channels() {
-    let mut cs = create_test_csound();
+    let cs = create_test_csound();
 
     cs.compile_orc(CONTROL_CHANNEL_ORC, 0)
         .expect("Failed to compile orchestra");

--- a/tests/channel_table_message_tests.rs
+++ b/tests/channel_table_message_tests.rs
@@ -8,6 +8,9 @@
 //! - Message buffer (create, drain messages)
 
 use csound::{Csound, MessageType, Myflt};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 /// Creates a Csound instance configured for testing.
 fn create_test_csound() -> Csound {
@@ -188,6 +191,56 @@ fn test_string_channel_unicode() {
         result, test_string,
         "Unicode string channel roundtrip failed"
     );
+}
+
+#[test]
+fn test_string_channel_lock_blocks_other_thread() {
+    let cs = create_test_csound();
+
+    cs.compile_orc(STRING_CHANNEL_ORC, 0)
+        .expect("Failed to compile orchestra");
+    cs.start().expect("Failed to start Csound");
+
+    let channel_a = cs
+        .get_input_channel::<csound::StrChannel>("message")
+        .expect("Failed to get string input channel");
+    let channel_b = cs
+        .get_input_channel::<csound::StrChannel>("message")
+        .expect("Failed to get string input channel");
+
+    let (tx_ready, rx_ready) = mpsc::channel();
+    let (tx_done, rx_done) = mpsc::channel();
+
+    thread::scope(|s| {
+        s.spawn(move || {
+            let _guard = channel_a.lock();
+            tx_ready
+                .send(())
+                .expect("Failed to signal lock acquisition");
+            thread::sleep(Duration::from_millis(120));
+            drop(_guard);
+            tx_done.send(()).expect("Failed to signal lock release");
+        });
+
+        rx_ready
+            .recv_timeout(Duration::from_secs(1))
+            .expect("Worker did not acquire lock in time");
+
+        let start = Instant::now();
+        let _guard = channel_b.lock();
+        let elapsed = start.elapsed();
+        drop(_guard);
+
+        rx_done
+            .recv_timeout(Duration::from_secs(1))
+            .expect("Worker did not release lock in time");
+
+        assert!(
+            elapsed >= Duration::from_millis(60),
+            "Lock did not block as expected (elapsed {:?})",
+            elapsed
+        );
+    });
 }
 
 // ============================================================================


### PR DESCRIPTION
Changes:

  - add ChannelLock guard (lock/unlock on drop) and mark lock as must-use
  - move pointer accessors to unsafe on InputChannel/OutputChannel; safe access via lock
  - store CSOUND* in channel handles to lock without needing &Csound
  - fix string channels to use csoundGet/SetStringData and dynamic datasize
  - allow string channel creation by deferring datasize lookup until after csoundGetChannelPtr
  - free control channel hint attributes to avoid leaks
  - check csoundInitialize return in Csound::new
  - use copy_from_slice for table/buffer copies
  - adjust audio channel write to accept larger buffers with warning
  - update examples and docs to use channel locking
  - add multithreaded lock contention test and other callback/channel tests