### PR TITLE
fix: treat already-initialized csoundInitialize as success

### DIFF
--- a/src/csound.rs
+++ b/src/csound.rs
@@ -3,7 +3,6 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
 use std::slice;
-use std::sync::OnceLock;
 
 use crate::channels::{
     ChannelBehavior, ChannelDir, ChannelHandle, ChannelHints, ChannelInfo, ChannelSpec,
@@ -70,9 +69,6 @@ pub(crate) struct Inner {
     host_data: NonNull<CallbackHandler<'static>>,
 }
 
-/// Global initialization guard - csound is initialized exactly once
-static CSOUND_INIT: OnceLock<i32> = OnceLock::new();
-
 // SAFETY: The CSOUND pointer can be safely sent between threads when:
 // 1. Access is externally synchronized (e.g., via Mutex), OR
 // 2. Only thread-safe Csound APIs are used (channels, message buffer)
@@ -107,18 +103,12 @@ impl Csound {
     /// });
     /// ```
     pub fn new() -> Result<Self> {
-        // Initialize csound library exactly once (thread-safe)
+        // Csound returns 0 on first init, positive if another module in this
+        // process already called csoundInitialize (a second stuffed VST3 copy
+        // of the same host). That is success — see Csound::initialize().
         let flags =
-            (csound_sys::CSOUNDINIT_NO_SIGNAL_HANDLER | csound_sys::CSOUNDINIT_NO_ATEXIT) as c_int;
-        let status = *CSOUND_INIT.get_or_init(|| unsafe { csound_sys::csoundInitialize(flags) });
-        match Status::from(status) {
-            Status::Success => {}
-            Status::Signal => return Err(Error::Signal),
-            Status::Memory => return Err(Error::Memory),
-            Status::Performance => return Err(Error::Performance),
-            Status::Initialization => return Err(Error::Initialization),
-            _ => return Err(Error::InitFailed),
-        }
+            (csound_sys::CSOUNDINIT_NO_SIGNAL_HANDLER | csound_sys::CSOUNDINIT_NO_ATEXIT) as i32;
+        Csound::initialize(flags)?;
 
         // Ensure MYFLT size matches the linked Csound library.
         let expected = std::mem::size_of::<crate::Myflt>();
@@ -190,16 +180,19 @@ impl Csound {
     ///
     /// # Errors
     ///
-    /// Returns an error if initialization fails.
+    /// Returns an error if initialization fails. Zero or a positive Csound
+    /// return (library already initialized by this process) is success;
+    /// a negative return is `InitFailed`.
     pub fn initialize(flags: i32) -> Result<()> {
         unsafe {
-            match csound_sys::csoundInitialize(flags as c_int) {
-                CSOUND_STATUS::CSOUND_ERROR => {
-                    tracing::error!(flags, "failed to initialize csound");
-                    Err(Error::InitFailed)
-                }
-                CSOUND_STATUS::CSOUND_SUCCESS => Ok(()),
-                _ => Ok(()), // Already initialized is not an error
+            let status = csound_sys::csoundInitialize(flags as c_int);
+            // 0 = first init in this process; positive = already initialized.
+            // Negative is a real failure (CSOUND_ERROR and friends).
+            if status >= 0 {
+                Ok(())
+            } else {
+                tracing::error!(flags, status, "failed to initialize csound");
+                Err(Error::InitFailed)
             }
         }
     }

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -82,6 +82,20 @@ instr 1
 endin
 "#;
 
+/// Two Csound instances in one process. The second `Csound::new` calls
+/// `csoundInitialize` again and gets a positive "already initialized"
+/// status; that must not be treated as `InitFailed`.
+///
+/// Stuffed VST3s are a stronger version of this (separate copies of the
+/// crate, one process-wide Csound library). This test covers the same
+/// return mapping inside a single crate.
+#[test]
+fn two_csound_instances_after_library_already_initialized() {
+    let a = create_test_csound();
+    let b = create_test_csound();
+    drop((a, b));
+}
+
 /// Test that a valid orchestra compiles successfully.
 #[test]
 fn test_compile_valid_orchestra() {

--- a/tests/differential.rs
+++ b/tests/differential.rs
@@ -221,16 +221,17 @@ fn read_doubles(path: &Path) -> Vec<f64> {
         "{} is empty; nothing was rendered",
         path.display()
     );
-    assert_eq!(
-        bytes.len() % std::mem::size_of::<f64>(),
-        0,
+
+    let (chunks, remainder) = bytes.as_chunks::<{ std::mem::size_of::<f64>() }>();
+    assert!(
+        remainder.is_empty(),
         "{} is not a whole number of f64 samples",
         path.display()
     );
 
-    bytes
-        .chunks_exact(std::mem::size_of::<f64>())
-        .map(|chunk| f64::from_ne_bytes(chunk.try_into().unwrap()))
+    chunks
+        .iter()
+        .map(|chunk| f64::from_ne_bytes(*chunk))
         .collect()
 }
 


### PR DESCRIPTION
A second stuffed VST3 in the same process calls csoundInitialize again and gets a positive status. Csound::new used OnceLock plus Status::from, which mapped that to InitFailed, so only the first plugin started. Each plugin has its own Rust statics; they share one process-wide Csound library.

Csound::new now reuses Csound::initialize. Only a negative return is InitFailed.