### PR TITLE
 Improve spin/spout buffer soundness

### DIFF
--- a/src/array_channel.rs
+++ b/src/array_channel.rs
@@ -367,7 +367,7 @@ impl<'lock, 'chan> ArrayChannelLock<'lock, 'chan> {
         let len = self.numeric_len()?;
         let ptr = unsafe { csoundGetArrayData(self.adat) } as *const Myflt;
         if ptr.is_null() {
-            return Err(Error::BufferNotInitialized("array channel has no data"));
+            return Err(Error::BufferNotInitialized);
         }
         if len == 0 {
             return Ok(&[]);
@@ -388,7 +388,7 @@ impl<'lock, 'chan> ArrayChannelLock<'lock, 'chan> {
         let len = self.numeric_len()?;
         let ptr = unsafe { csoundGetArrayData(self.adat) } as *mut Myflt;
         if ptr.is_null() {
-            return Err(Error::BufferNotInitialized("array channel has no data"));
+            return Err(Error::BufferNotInitialized);
         }
         if len == 0 {
             return Ok(&mut []);
@@ -457,7 +457,7 @@ impl<'lock, 'chan> ArrayChannelLock<'lock, 'chan> {
         let len = self.numeric_len()?;
 
         if unsafe { csoundGetArrayData(self.adat) }.is_null() {
-            return Err(Error::BufferNotInitialized("array channel has no data"));
+            return Err(Error::BufferNotInitialized);
         }
 
         if input.len() != len {
@@ -581,9 +581,7 @@ impl Csound {
             return Err(Error::NullPointer("failed to initialize array channel"));
         }
         if array_data_ptr(adat).is_null() {
-            return Err(Error::BufferNotInitialized(
-                "array channel storage was not allocated",
-            ));
+            return Err(Error::BufferNotInitialized);
         }
 
         unsafe { ArrayChannel::from_raw(self.csound_ptr(), cname, adat, self.get_ksmps()) }
@@ -629,9 +627,7 @@ impl Csound {
                 // A channel entry can exist without storage; reading its type in
                 // that state dereferences a NULL `arrayType` inside Csound.
                 if array_data_ptr(adat).is_null() {
-                    return Err(Error::BufferNotInitialized(
-                        "array channel exists but has not been initialized",
-                    ));
+                    return Err(Error::BufferNotInitialized);
                 }
 
                 unsafe { ArrayChannel::from_raw(self.csound_ptr(), cname, adat, self.get_ksmps()) }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1220,7 +1220,7 @@ endin
 
     #[test]
     fn input_channel_callback_string_copy() {
-        let cs = Csound::new().expect("Failed to create Csound instance");
+        let mut cs = Csound::new().expect("Failed to create Csound instance");
         cs.set_option("-n").expect("Failed to set -n option");
         cs.set_option("-d").expect("Failed to set -d option");
         cs.set_option("-m0").expect("Failed to set -m0 option");

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
 use std::slice;
 
@@ -445,7 +444,7 @@ impl Csound {
         }
     }
 
-    // TODO Implement csoundCompileTree functions
+    // TODO: Implement csoundCompileTree functions
 
     /// Senses input events, and performs one control sample worth ```ksmps * number of channels * size_of::<Myflt> bytes``` of audio output.
     ///
@@ -453,7 +452,10 @@ impl Csound {
     /// Enables external software to control the execution of Csound, and to synchronize
     /// performance with audio input and output(see: [`Csound::read_spin_buffer`](struct.Csound.html#method.read_spin_buffer), [`Csound::read_spout_buffer`](struct.Csound.html#method.read_spout_buffer))
     /// # Returns
-    /// *false* during performance, and true when performance has finished. If called until it returns *true*, will perform an entire score.
+    /// *false*: during performance.
+    /// *true*: when performance has finished.
+    ///
+    /// If called until it returns *true*, will perform an entire score.
     pub fn perform_ksmps(&self) -> bool {
         unsafe { csound_sys::csoundPerformKsmps(self.csound_ptr()) != 0 }
     }
@@ -748,33 +750,36 @@ impl Csound {
     /// ```ignore
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new().unwrap();
+    /// let mut csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
-    /// let spin = csound.get_spin();
-    /// while !csound.perform_ksmps() {
-    ///     // fills the spin buffer with audio samples that you want to pass into csound
-    ///     // foo_fill_buffer(spin.as_mut_slice());
-    ///     // ...
+    /// loop {
+    ///     // Scope the writable view so it is dropped before performance mutates the engine.
+    ///     {
+    ///         let mut spin = csound.get_spin().unwrap();
+    ///         // Fill the spin buffer with audio samples to pass into Csound.
+    ///         // foo_fill_buffer(spin.as_mut_slice());
+    ///     }
+    ///
+    ///     if csound.perform_ksmps() {
+    ///         break;
+    ///     }
     /// }
     /// ```
     #[must_use]
-    pub fn get_spin(&self) -> Option<BufferPtr<'_, Writable>> {
+    pub fn get_spin(&mut self) -> Option<BufferPtr<'_, Writable>> {
         unsafe {
-            let ptr = csound_sys::csoundGetSpin(self.csound_ptr()) as *mut Myflt;
+            let ptr = NonNull::new(csound_sys::csoundGetSpin(self.csound_ptr()) as *mut Myflt)?;
             let len = (self.get_ksmps() * self.get_channels(1)) as usize;
-            if !ptr.is_null() {
-                return Some(BufferPtr {
-                    ptr,
-                    len,
-                    phantom: PhantomData,
-                });
-            }
-            None
+            Some(BufferPtr {
+                ptr,
+                len,
+                phantom: PhantomData,
+            })
         }
     }
 
-    /// Enables external software to read audio from  Csound before calling perform_ksmps.
+    /// Enables external software to read audio from Csound after calling perform_ksmps.
     /// # Returns
     /// An Option containing either the [`BufferPtr`](struct.BufferPtr.html) or None if the
     /// csound's spout buffer has not been initialized. The returned *BufferPtr* is only Readable.
@@ -782,72 +787,69 @@ impl Csound {
     /// ```ignore
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new().unwrap();
+    /// let mut csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
-    /// let spout = csound.get_spout();
-    /// while !csound.perform_ksmps() {
-    ///     // Deref the spout pointer and read its content
-    ///     // foo_read_buffer(&*spout);
-    ///     // ...
+    /// loop {
+    ///     if csound.perform_ksmps() {
+    ///         break;
+    ///     }
+    ///
+    ///     // Obtain the readable view after performance has filled the spout buffer.
+    ///     // Its borrow ends before the next call to perform_ksmps().
+    ///     {
+    ///         let spout = csound.get_spout().unwrap();
+    ///         // foo_read_buffer(spout.as_slice());
+    ///     }
     /// }
     /// ```
     #[must_use]
-    pub fn get_spout(&self) -> Option<BufferPtr<'_, Readable>> {
+    pub fn get_spout(&mut self) -> Option<BufferPtr<'_, Readable>> {
         unsafe {
-            let ptr = csound_sys::csoundGetSpout(self.csound_ptr()) as *mut Myflt;
+            let ptr = NonNull::new(csound_sys::csoundGetSpout(self.csound_ptr()) as *mut Myflt)?;
             let len = (self.get_ksmps() * self.get_channels(0)) as usize;
-            if !ptr.is_null() {
-                return Some(BufferPtr {
-                    ptr,
-                    len,
-                    phantom: PhantomData,
-                });
-            }
-            None
+            Some(BufferPtr {
+                ptr,
+                len,
+                phantom: PhantomData,
+            })
         }
     }
 
     /// Enables external software to read audio from Csound after calling [`Csound::perform_ksmps`](struct.Csound.html#method.perform_ksmps)
     /// # Returns
     /// The number of samples copied  or an
-    /// error message if the internal csound's buffer has not been initialized.
+    /// error if the internal csound's buffer has not been initialized.
     /// # Example
     /// ```ignore
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new().unwrap();
+    /// let mut csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spout_length = csound.get_ksmps() * csound.get_channels(0); // get output channels
     /// let mut spout_buffer = vec![0 as Myflt; spout_length as usize];
-    /// while !csound.perform_ksmps() {
-    ///     // fills your buffer with audio samples you want to pass into csound
-    ///     // foo_fill_buffer(&mut spout_buffer);
-    ///     csound.read_spout_buffer(&mut spout_buffer);
-    ///     // ...
+    /// loop {
+    ///     if csound.perform_ksmps() {
+    ///         break;
+    ///     }
+    ///     csound.read_spout(&mut spout_buffer);
+    ///     // Process the samples copied from Csound.
+    ///     // foo_read_buffer(&spout_buffer);
     /// }
     /// ```
-    /// # Deprecated
-    /// Use [`Csound::get_spout`](struct.Csound.html#method.get_spout) to get a [`BufferPtr`](struct.BufferPtr.html)
-    /// object.
-    #[deprecated(since = "0.1.5", note = "please use Csound::get_spout object instead")]
-    pub fn read_spout_buffer(&self, output: &mut [Myflt]) -> Result<usize> {
-        let size = self.get_ksmps() as usize * self.get_channels(0) as usize;
-        let spout = unsafe { csound_sys::csoundGetSpout(self.csound_ptr()) as *mut Myflt };
-        let mut len = output.len();
-        if size < len {
-            len = size;
+    pub fn read_spout(&self, output: &mut [Myflt]) -> Result<usize> {
+        let spout_len = self.get_ksmps() as usize * self.get_channels(0) as usize;
+        let spout =
+            NonNull::new(unsafe { csound_sys::csoundGetSpout(self.csound_ptr()) as *mut Myflt })
+                .ok_or(Error::BufferNotInitialized)?;
+
+        let len = spout_len.min(output.len());
+
+        unsafe {
+            std::ptr::copy(spout.as_ptr(), output.as_mut_ptr(), len);
         }
-        if !spout.is_null() {
-            unsafe {
-                std::ptr::copy(spout, output.as_mut_ptr(), len);
-                return Ok(len);
-            }
-        }
-        Err(Error::BufferNotInitialized(
-            "spout buffer not initialized, call compile() and start() first",
-        ))
+        Ok(len)
     }
 
     /// Enables external software to write audio into Csound before calling [`Csound::perform_ksmps`](struct.Csound.html#method.perform_ksmps)
@@ -859,38 +861,45 @@ impl Csound {
     /// ```ignore
     /// use csound::Csound;
     ///
-    /// let csound = Csound::new().unwrap();
+    /// let mut csound = Csound::new().unwrap();
     /// csound.compile_csd("some_file_path", 0, 0);
     /// csound.start();
     /// let spin_length = csound.get_ksmps() * csound.get_channels(1); // get input channels
     /// let mut spin_buffer = vec![0 as Myflt; spin_length as usize];
-    /// while !csound.perform_ksmps() {
-    ///     // fills your buffer with audio samples you want to pass into csound
+    /// loop {
+    ///     // Fill the input buffer before performing the next block.
     ///     // foo_fill_buffer(&mut spin_buffer);
-    ///     csound.write_spin_buffer(&spin_buffer);
-    ///     // ...
+    ///     csound.write_spin(&spin_buffer);
+    ///
+    ///     if csound.perform_ksmps() {
+    ///         break;
+    ///     }
     /// }
     /// ```
-    /// # Deprecated
-    /// Use [`Csound::get_spin`](struct.Csound.html#method.get_spin) to get a [`BufferPtr`](struct.BufferPtr.html)
-    /// object.
-    #[deprecated(since = "0.1.5", note = "please use Csound::get_spin object instead")]
-    pub fn write_spin_buffer(&self, input: &[Myflt]) -> Result<usize> {
-        let size = self.get_ksmps() as usize * self.get_channels(1) as usize;
-        let spin = unsafe { csound_sys::csoundGetSpin(self.csound_ptr()) as *mut Myflt };
-        let mut len = input.len();
-        if size < len {
-            len = size;
+    ///
+    /// # Note
+    /// If `input` is shorter than the internal spin buffer, the remaining
+    /// samples are filled with zeroes to prevent samples from the previous
+    /// processing block from being reused. If it is longer, only the first
+    /// `spin_len` samples are copied.
+    pub fn write_spin(&self, input: &[Myflt]) -> Result<usize> {
+        let spin_len = self.get_ksmps() as usize * self.get_channels(1) as usize;
+        let mut spin =
+            NonNull::new(unsafe { csound_sys::csoundGetSpin(self.csound_ptr()) as *mut Myflt })
+                .ok_or(Error::BufferNotInitialized)?;
+
+        let len = spin_len.min(input.len());
+        let spin_array = unsafe { std::slice::from_raw_parts_mut(spin.as_mut(), spin_len) };
+        if len < spin_len {
+            spin_array
+                .iter_mut()
+                .skip(len)
+                .for_each(|v| *v = Myflt::default());
         }
-        if !spin.is_null() {
-            unsafe {
-                std::ptr::copy(input.as_ptr(), spin, len);
-                return Ok(len);
-            }
-        }
-        Err(Error::BufferNotInitialized(
-            "spin buffer not initialized, call compile() and start() first",
-        ))
+
+        spin_array[..len].copy_from_slice(&input[..len]);
+
+        Ok(len)
     }
 
     ///Calling this function after csoundCreate()
@@ -2794,7 +2803,7 @@ pub enum Writable {}
 /// Csound buffer pointer representation.
 /// This struct is build up to manipulate directly csound's buffers.
 pub struct BufferPtr<'a, T> {
-    ptr: *mut Myflt,
+    ptr: NonNull<Myflt>,
     len: usize,
     phantom: PhantomData<&'a T>,
 }
@@ -2805,7 +2814,9 @@ impl<'a, T> BufferPtr<'a, T> {
     pub fn get_size(&self) -> usize {
         self.len
     }
+}
 
+impl<'a> BufferPtr<'a, Readable> {
     /// This method is used to copy data from the csound's buffer
     /// into another slice.
     /// # Arguments
@@ -2821,7 +2832,7 @@ impl<'a, T> BufferPtr<'a, T> {
     /// # Returns
     /// A slice to the buffer internal data
     pub fn as_slice(&self) -> &[Myflt] {
-        unsafe { slice::from_raw_parts(self.ptr, self.len) }
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
     }
 }
 
@@ -2829,7 +2840,7 @@ impl<'a> BufferPtr<'a, Writable> {
     /// # Returns
     /// This buffer pointer as a mutable slice.
     pub fn as_mut_slice(&mut self) -> &mut [Myflt] {
-        unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
 
     /// method used to copy data into this buffer
@@ -2837,11 +2848,11 @@ impl<'a> BufferPtr<'a, Writable> {
     /// * `slice` A slice with samples to copy
     /// # Returns
     /// The number of elements copied into the csound's buffer.
-    pub fn copy_from_slice(&self, slice: &[Myflt]) -> usize {
+    pub fn copy_from_slice(&mut self, slice: &[Myflt]) -> usize {
         let len = slice.len().min(self.get_size());
         // SAFETY: pointer is valid for the buffer lifetime; length is bounded by buffer size.
         unsafe {
-            let dst = slice::from_raw_parts_mut(self.ptr, len);
+            let dst = slice::from_raw_parts_mut(self.ptr.as_ptr(), len);
             dst.copy_from_slice(&slice[..len]);
         }
         len
@@ -2853,7 +2864,7 @@ impl<'a> BufferPtr<'a, Writable> {
     }
 }
 
-impl<'a, T> AsRef<[Myflt]> for BufferPtr<'a, T> {
+impl<'a> AsRef<[Myflt]> for BufferPtr<'a, Readable> {
     fn as_ref(&self) -> &[Myflt] {
         self.as_slice()
     }
@@ -2861,19 +2872,6 @@ impl<'a, T> AsRef<[Myflt]> for BufferPtr<'a, T> {
 
 impl<'a> AsMut<[Myflt]> for BufferPtr<'a, Writable> {
     fn as_mut(&mut self) -> &mut [Myflt] {
-        self.as_mut_slice()
-    }
-}
-
-impl<'a, T> Deref for BufferPtr<'a, T> {
-    type Target = [Myflt];
-    fn deref(&self) -> &[Myflt] {
-        self.as_slice()
-    }
-}
-
-impl<'a> DerefMut for BufferPtr<'a, Writable> {
-    fn deref_mut(&mut self) -> &mut [Myflt] {
         self.as_mut_slice()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,8 +61,8 @@ pub enum Error {
     AlreadyStarted,
 
     /// An internal buffer has not been initialized.
-    #[error("buffer not initialized: {0}")]
-    BufferNotInitialized(&'static str),
+    #[error("buffer not initialized")]
+    BufferNotInitialized,
 
     /// An empty string was provided where content was expected.
     #[error("empty string provided")]

--- a/src/pvs_channel.rs
+++ b/src/pvs_channel.rs
@@ -492,9 +492,7 @@ impl Csound {
         }
 
         if channel.with_lock(|lock| lock.frame_ptr().is_null()) {
-            return Err(Error::BufferNotInitialized(
-                "PVS channel frame not initialized",
-            ));
+            return Err(Error::BufferNotInitialized);
         }
 
         Ok(channel)
@@ -533,9 +531,7 @@ impl Csound {
                         .ok_or(Error::NullPointer("failed to create PVS channel"))?;
 
                 if channel.with_lock(|lock| lock.frame_ptr().is_null()) {
-                    return Err(Error::BufferNotInitialized(
-                        "PVS channel frame not initialized",
-                    ));
+                    return Err(Error::BufferNotInitialized);
                 }
 
                 Ok(channel)

--- a/tests/array_channel.rs
+++ b/tests/array_channel.rs
@@ -357,7 +357,7 @@ fn get_uninitialized_array_channel_is_rejected() {
     let err = cs
         .get_array_channel("never_initialized")
         .expect_err("uninitialized array channel must be rejected");
-    assert!(matches!(err, Error::BufferNotInitialized(_)));
+    assert!(matches!(err, Error::BufferNotInitialized));
 }
 
 #[test]
@@ -436,7 +436,7 @@ fn write_helper_copies_min_length() {
 
 #[test]
 fn sequential_locks_do_not_deadlock() {
-    let cs = started_csound(ORC);
+    let mut cs = started_csound(ORC);
     let chan = cs.init_array_channel("seqlock", "k", &[2]).unwrap();
 
     for i in 0..16 {
@@ -450,7 +450,7 @@ fn sequential_locks_do_not_deadlock() {
 
 #[test]
 fn is_empty_reflects_length() {
-    let cs = started_csound(ORC);
+    let mut cs = started_csound(ORC);
     let chan = cs.init_array_channel("nonempty", "k", &[2]).unwrap();
     chan.with_lock(|lock| {
         assert!(!lock.is_empty());
@@ -464,7 +464,7 @@ fn is_empty_reflects_length() {
 
 #[test]
 fn host_writes_orchestra_reads() {
-    let cs = started_csound(INTEROP_ORC);
+    let mut cs = started_csound(INTEROP_ORC);
 
     let chan = cs
         .init_array_channel("host_to_orc", "k", &[4])
@@ -484,7 +484,7 @@ fn host_writes_orchestra_reads() {
 
 #[test]
 fn orchestra_writes_host_reads() {
-    let cs = started_csound(INTEROP_ORC);
+    let mut cs = started_csound(INTEROP_ORC);
 
     cs.send_score_event(ScoreEventType::Instrument, &[11.0, 0.0, 1.0]);
     for _ in 0..8 {
@@ -502,11 +502,11 @@ fn orchestra_writes_host_reads() {
 
 #[test]
 fn host_update_is_visible_to_orchestra_across_k_periods() {
-    let cs = started_csound(INTEROP_ORC);
-
-    let chan = cs.init_array_channel("host_to_orc", "k", &[4]).unwrap();
-    chan.set_data(&[1.0, 0.0, 0.0, 2.0]).unwrap();
-
+    let mut cs = started_csound(INTEROP_ORC);
+    {
+        let chan = cs.init_array_channel("host_to_orc", "k", &[4]).unwrap();
+        chan.set_data(&[1.0, 0.0, 0.0, 2.0]).unwrap();
+    }
     cs.send_score_event(ScoreEventType::Instrument, &[10.0, 0.0, 10.0]);
     for _ in 0..4 {
         cs.perform_ksmps();
@@ -514,7 +514,10 @@ fn host_update_is_visible_to_orchestra_across_k_periods() {
     assert_eq!(cs.get_control_channel("readback0").unwrap(), 1.0);
 
     // Update from the host mid-performance; the orchestra should observe it.
-    chan.set_data(&[99.0, 0.0, 0.0, 98.0]).unwrap();
+    {
+        let chan = cs.get_array_channel("host_to_orc").unwrap();
+        chan.set_data(&[99.0, 0.0, 0.0, 98.0]).unwrap();
+    }
     for _ in 0..4 {
         cs.perform_ksmps();
     }

--- a/tests/debugger.rs
+++ b/tests/debugger.rs
@@ -72,7 +72,7 @@ fn breakpoints_can_be_set_and_cleared() {
 
 #[test]
 fn instrument_breakpoint_fires_once() {
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1.1 0 1 440", 0)
@@ -110,7 +110,7 @@ fn instrument_breakpoint_fires_once() {
 
 #[test]
 fn breakpoint_can_resume_and_remove_itself() {
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1.1 0 1 440", 0).unwrap();
@@ -145,7 +145,7 @@ fn breakpoint_can_resume_and_remove_itself() {
 
 #[test]
 fn no_breakpoint_means_no_callback() {
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 1 440", 0).unwrap();
@@ -169,7 +169,7 @@ fn no_breakpoint_means_no_callback() {
 
 #[test]
 fn k_cycle_callback_fires_every_cycle() {
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();
@@ -195,7 +195,7 @@ fn k_cycle_callback_fires_every_cycle() {
 
 #[test]
 fn k_cycle_callback_can_be_removed() {
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();
@@ -227,7 +227,7 @@ fn k_cycle_callback_can_be_removed() {
 #[test]
 fn callback_panic_is_contained() {
     // A panic must not unwind across the FFI boundary; it is caught and logged.
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();
@@ -247,7 +247,7 @@ fn callback_panic_is_contained() {
 
 #[test]
 fn instrument_instances_are_listed_during_performance() {
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();
@@ -273,7 +273,7 @@ fn instrument_variables_are_readable() {
     // A k-rate variable with a known value, so the read can be checked.
     let orc = "instr 1\nkval init 42.5\nasig oscil 1, p4\nendin\n";
 
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(orc, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();
@@ -309,7 +309,7 @@ fn instrument_variables_are_readable() {
 fn variable_type_mismatch_is_rejected() {
     let orc = "instr 1\nkval init 1\nasig oscil 1, p4\nendin\n";
 
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(orc, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();
@@ -340,7 +340,7 @@ fn variable_type_mismatch_is_rejected() {
 fn global_variables_are_listed() {
     let orc = "gkglob init 7\ninstr 1\nasig oscil 1, p4\nendin\n";
 
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(orc, 0).expect("compile failed");
     cs.start().expect("start failed");
 
@@ -377,7 +377,7 @@ fn global_array_serializes() {
                asig oscil 1, p4\n\
                endin\n";
 
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(orc, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 1 440", 0).unwrap();
@@ -409,7 +409,7 @@ fn udo_frames_are_listed() {
                asig oscil 1, p4\n\
                endin\n";
 
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(orc, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();
@@ -458,7 +458,7 @@ fn replacing_a_callback_does_not_dangle() {
     // Installing a second callback drops the first. The engine must be pointed
     // at the new closure before the old one is freed, or it briefly holds a
     // dangling pointer. Run under `just asan` to check that directly.
-    let cs = create_test_csound();
+    let mut cs = create_test_csound();
     cs.compile_orc(ORC, 0).expect("compile failed");
     cs.start().expect("start failed");
     cs.send_string_event("i 1 0 2 440", 0).unwrap();

--- a/tests/differential.rs
+++ b/tests/differential.rs
@@ -331,8 +331,12 @@ fn spout_stream_matches_frontend_output() {
     let mut guard = 0;
     while !cs.perform_ksmps() {
         let spout = cs.get_spout().expect("spout buffer not available");
-        assert_eq!(spout.len(), frame, "spout length changed mid-performance");
-        captured.extend_from_slice(&spout);
+        assert_eq!(
+            spout.get_size(),
+            frame,
+            "spout length changed mid-performance"
+        );
+        captured.extend_from_slice(spout.as_slice());
 
         guard += 1;
         assert!(guard < 100_000, "performance did not terminate");


### PR DESCRIPTION
 This PR strengthens direct access to Csound’s internal audio buffers while preserving existing channel and debugger workflows.

 ### Changes

 - Require &mut Csound when obtaining spin or spout views, preventing performance while a view remains live.
 - Keep perform_ksmps(&self) so synchronized channel/debugger handles can coexist with performance.
 - Require mutable access for writable BufferPtr operations.
 - Replace raw pointers with NonNull.
 - Remove generic Deref/DerefMut access in favor of explicit readable/writable methods.
 - Rename copy APIs to read_spout and write_spin.
 - Zero-pad short write_spin input to prevent stale samples from previous blocks.
 - Update examples and tests to scope buffer views correctly and use the explicit BufferPtr API
 
### Note

Breaking changes, however it should be easy to update 