### PR TITLE
fix: compile on Windows with LLVM 22 and MSVC integer widths

### DIFF
--- a/csound-sys/Cargo.toml
+++ b/csound-sys/Cargo.toml
@@ -16,4 +16,4 @@ exclude = ["csound/_codeql_detected_source_root"]
 libc = "1.0.0-alpha.1"
 
 [build-dependencies]
-bindgen = "0.71.1"
+bindgen = "0.72.1"

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -834,6 +834,8 @@ pub mod Trampoline {
 
                 // Bindgen's enum constant type is c_int vs c_uint depending on
                 // the C compiler; compare as u32 instead of matching the const.
+                // The `as u32` is identity on Unix and required on MSVC.
+                #[allow(clippy::unnecessary_cast)]
                 match channel_type as u32 {
                     t if t == controlChannelType::CSOUND_CONTROL_CHANNEL as u32 => {
                         let value = *(channelValuePtr as *mut Myflt);

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -832,13 +832,15 @@ pub mod Trampoline {
                     return;
                 };
 
+                // Bindgen's enum constant type is c_int vs c_uint depending on
+                // the C compiler; compare as u32 instead of matching the const.
                 match channel_type as u32 {
-                    controlChannelType::CSOUND_CONTROL_CHANNEL => {
+                    t if t == controlChannelType::CSOUND_CONTROL_CHANNEL as u32 => {
                         let value = *(channelValuePtr as *mut Myflt);
                         let data = ChannelData::Control(value);
                         fun(name, data);
                     }
-                    controlChannelType::CSOUND_STRING_CHANNEL => {
+                    t if t == controlChannelType::CSOUND_STRING_CHANNEL as u32 => {
                         let data = ChannelData::String(
                             ptr_to_string(channelValuePtr as *const c_char).unwrap_or_default(),
                         );

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -1211,6 +1211,8 @@ impl Csound {
                     name,
                     type_: channel_info.type_,
                     hints: ChannelHints {
+                        // Identity on Unix; bindgen emits i32 for this enum on MSVC.
+                        #[allow(clippy::unnecessary_cast)]
                         behav: ChannelBehavior::from(channel_info.hints.behav as u32),
                         dflt: channel_info.hints.dflt,
                         min: channel_info.hints.min,
@@ -1571,6 +1573,8 @@ impl Csound {
                     Some(result?)
                 };
                 Ok(ChannelHints {
+                    // Identity on Unix; bindgen emits i32 for this enum on MSVC.
+                    #[allow(clippy::unnecessary_cast)]
                     behav: ChannelBehavior::from(hint.behav as u32),
                     dflt: hint.dflt,
                     min: hint.min,
@@ -2294,8 +2298,9 @@ impl Csound {
     /// The elapsed real time (in seconds) since the specified timer
     pub fn get_real_time(timer: &RTCLOCK) -> f64 {
         unsafe {
+            // C type is int_least64_t; c_long is 32-bit on MSVC.
+            #[allow(clippy::unnecessary_cast)]
             let ptr: *mut csound_sys::RTCLOCK = &mut csound_sys::RTCLOCK {
-                // C type is int_least64_t; c_long is 32-bit on MSVC.
                 starttime_real: timer.starttime_real as i64,
                 starttime_CPU: timer.starttime_CPU as i64,
             };

--- a/src/csound.rs
+++ b/src/csound.rs
@@ -15,12 +15,12 @@ use crate::error::{Error, Result};
 use crate::rtaudio::{CsAudioDevice, CsMidiDevice, RtAudioParams};
 use crate::{Myflt, TableId, callbacks::*};
 
-use csound_sys::{CSOUND_STATUS, RTCLOCK, controlChannelType};
+use csound_sys::{CSOUND_STATUS, RTCLOCK, controlChannelBehavior, controlChannelType};
 
 use std::ffi::{CStr, CString};
 use std::str;
 
-use libc::{c_char, c_int, c_long, c_void};
+use libc::{c_char, c_int, c_void};
 
 /// Struct with information about a csound opcode.
 ///
@@ -1211,7 +1211,7 @@ impl Csound {
                     name,
                     type_: channel_info.type_,
                     hints: ChannelHints {
-                        behav: ChannelBehavior::from(channel_info.hints.behav),
+                        behav: ChannelBehavior::from(channel_info.hints.behav as u32),
                         dflt: channel_info.hints.dflt,
                         min: channel_info.hints.min,
                         max: channel_info.hints.max,
@@ -1502,7 +1502,7 @@ impl Csound {
         };
         let cname = CString::new(name)?;
         let channel_hint = csound_sys::controlChannelHints_t {
-            behav: ChannelBehavior::to_u32(hint.behav),
+            behav: ChannelBehavior::to_u32(hint.behav) as controlChannelBehavior::Type,
             dflt: hint.dflt,
             min: hint.min,
             max: hint.max,
@@ -1571,7 +1571,7 @@ impl Csound {
                     Some(result?)
                 };
                 Ok(ChannelHints {
-                    behav: ChannelBehavior::from(hint.behav),
+                    behav: ChannelBehavior::from(hint.behav as u32),
                     dflt: hint.dflt,
                     min: hint.min,
                     max: hint.max,
@@ -2248,7 +2248,7 @@ impl Csound {
     /// variable.
     pub fn set_language(lang_code: Language) {
         unsafe {
-            csound_sys::csoundSetLanguage(lang_code as u32);
+            csound_sys::csoundSetLanguage(lang_code as csound_sys::cslanguage_t::Type);
         }
     }
 
@@ -2295,8 +2295,9 @@ impl Csound {
     pub fn get_real_time(timer: &RTCLOCK) -> f64 {
         unsafe {
             let ptr: *mut csound_sys::RTCLOCK = &mut csound_sys::RTCLOCK {
-                starttime_real: timer.starttime_real as c_long,
-                starttime_CPU: timer.starttime_CPU as c_long,
+                // C type is int_least64_t; c_long is 32-bit on MSVC.
+                starttime_real: timer.starttime_real as i64,
+                starttime_CPU: timer.starttime_CPU as i64,
             };
             csound_sys::csoundGetRealTime(ptr) as f64
         }


### PR DESCRIPTION
Bump bindgen 0.71.1 → 0.72.1 so generated C unions match LLVM 22 layouts. Cast channel hints, language, and RTCLOCK fields through the bindgen Type aliases: c_long is 32-bit on MSVC, and C enums come through as i32 vs u32 depending on the compiler.